### PR TITLE
Add CBA settings file, with some settings

### DIFF
--- a/ARCMT.vr/cba_settings.sqf
+++ b/ARCMT.vr/cba_settings.sqf
@@ -1,0 +1,26 @@
+// ACE Weather
+/*
+	ACE Weather overrides mission maker environmental options,
+	as such it is disabled here. If you want semi-random
+	weather, feel free to enable it below.
+
+	Do note that weather wind simulation is not the same
+	as wind deflection.
+*/
+force ace_weather_enabled = false;
+force ace_weather_windSimulation = false;
+
+// ARC Misc
+/*
+	This setting disables visibility checks for non-local units.
+	In a general sense, this means that players will not have to
+	process visibility for AI units, which will save some CPU
+	time. This however means that scripts relying on accurate
+	knowsAbout values, such as detected by triggers, are not
+	guaranteed to function on clients.
+
+	When using such scripting, disable this setting.
+
+	https://community.bistudio.com/wiki/disableRemoteSensors
+*/
+force arc_misc_difficulty_disableRemoteSensors = true;

--- a/ARCMT.vr/description.ext
+++ b/ARCMT.vr/description.ext
@@ -1,5 +1,6 @@
 tmf_version[] = {1,1,1}; // DO NOT CHANGE THIS. This is the core version of the template that your mission was started with.
 enableDebugConsole = 1; // Allows the logged in admin to use the debug console from the escape page.
+cba_settings_hasSettingsFile = 1;
 
 // Use a randomized loading image from TMF. Set your own loading image with e.g. overviewPicture = "image.jpg";
 overviewPicture = __EVAL(selectRandom ['\x\tmf\addons\common\ui\loadscreens\1.jpg','\x\tmf\addons\common\ui\loadscreens\2.jpg','\x\tmf\addons\common\ui\loadscreens\3.jpg','\x\tmf\addons\common\ui\loadscreens\4.jpg','\x\tmf\addons\common\ui\loadscreens\5.jpg','\x\tmf\addons\common\ui\loadscreens\6.jpg','\x\tmf\addons\common\ui\loadscreens\7.jpg','\x\tmf\addons\common\ui\loadscreens\8.jpg','\x\tmf\addons\common\ui\loadscreens\9.jpg','\x\tmf\addons\common\ui\loadscreens\10.jpg']);

--- a/ARCMT.vr/loadouts/example_loadout.hpp
+++ b/ARCMT.vr/loadouts/example_loadout.hpp
@@ -8,13 +8,13 @@ class baseMan {// Weaponless baseclass
 	vest[] = {"V_PlateCarrier1_rgr","V_PlateCarrier2_rgr"};
 	backpack[] = {"B_AssaultPack_mcamo"};
 	headgear[] = {};
-	goggles[] = {"default"};
 	hmd[] = {};
 	// Leave empty to remove all. "Default" > leave original item.
-	faces[] = {"faceset:african", "faceset:caucasian"};
+	goggles[] = {"default"};
 	// Leave empty to not change faces.
-	insignias[] = {"111thID"};
+	faces[] = {"faceset:african", "faceset:caucasian"};
 	// Leave empty to not change insignias
+	insignias[] = {"111thID"};
 
 	// All randomized
 	primaryWeapon[] = {};


### PR DESCRIPTION
This file will be read and its settings applied in the mission. The reason for adding it is that the addon options UI is difficult to navigate to see what settings have been edited, compared to reading the file.

Additionally, the disable remote sensors setting has been enabled, which may lead to performance gains at the cost of increased vulnerability for locality issues when using scripts that rely on knowsAbout.

ACE Weather settings have also been included, to make it more clear that it more easily toggleable for missions.