### PR TITLE
4.0.0

### DIFF
--- a/ARCMT.vr/description.ext
+++ b/ARCMT.vr/description.ext
@@ -32,4 +32,16 @@ class CfgLoadouts {
 		displayName = "Example Loadout";
 		#include "loadouts\example_loadout.hpp"
 	};
+
+	// Example import and modification of loadout
+	import BLU_F from CfgLoadouts;
+	class BLU_F: BLU_F {
+		// Add some explosives to the engineer
+		class eng: eng {
+			backpackitems[] += {
+				"SatchelCharge_Remote_Mag",
+				LIST_3("DemoCharge_Remote_Mag")
+			};
+		};
+	};
 };

--- a/ARCMT.vr/loadouts/example_loadout.hpp
+++ b/ARCMT.vr/loadouts/example_loadout.hpp
@@ -33,7 +33,11 @@ class baseMan {// Weaponless baseclass
 
 	// These are added to the uniform or vest
 	magazines[] = {};
-	items[] = { MEDICAL_R };
+	items[] = {
+		MEDICAL_R,
+		"ACE_EntrenchingTool",
+		LIST_3("ACE_CableTie")
+	};
 	// These are added directly into their respective slots
 	linkedItems[] = {
 		"ItemMap",
@@ -91,6 +95,7 @@ class m : cls {
 	displayName = "Medic";
 	backpack[] = {"B_Carryall_mcamo"};
 	backpackItems[] = { MEDICAL_M };
+	linkedItems[] += {"Binocular"};
 };
 
 class smg : r {
@@ -101,6 +106,7 @@ class smg : r {
 		LIST_2("HandGrenade"),
 		LIST_2("SmokeShell")
 	};
+	items[] = { MEDICAL_R };
 };
 
 class ftl : g {
@@ -164,8 +170,7 @@ class ar : r {
 class aar : r {
 	displayName = "Assistant Automatic Rifleman";
 	backpackItems[] = {
-		LIST_4("100Rnd_65x39_caseless_mag"),
-		"ACE_EntrenchingTool"
+		LIST_4("100Rnd_65x39_caseless_mag")
 	};
 	linkedItems[] += {"Binocular"};
 };
@@ -481,41 +486,24 @@ class jp : smg {
 	};
 };
 
-class eng : car {
-	displayName = "Combat Engineer (Explosives)";
-	traits[] = {"engineer", "explosiveSpecialist"};
+class logi : car {
+	displayName = "Logistics";
+	traits[] = {"engineer"};
 	backpack[] = {"B_Kitbag_rgr"};
-	vest[] = {"V_PlateCarrier3_rgr"};
-	sidearmWeapon[] = {"ACE_VMM3"};
 	items[] += {
-		"ACE_wirecutter",
-		"ACE_Clacker",
-		"ACE_DefusalKit",
-		"ACE_EntrenchingTool"
+		"ACE_wirecutter"
 	};
-	backpackItems[] = {
-		"ToolKit",
-		LIST_2("DemoCharge_Remote_Mag"),
-		LIST_2("ClaymoreDirectionalMine_Remote_Mag"),
-		"SatchelCharge_Remote_Mag"
-	};
+	linkedItems[] += {"ItemGPS"};
+	backpackItems[] = {"ToolKit"};
 };
 
-class engm : car {
-	displayName = "Combat Engineer (Mines)";
-	traits[] = {"engineer", "explosiveSpecialist"};
-	backpack[] = {"B_Kitbag_rgr"};
-	vest[] = {"V_PlateCarrier3_rgr"};
+class eng : logi {
+	displayName = "Combat Engineer";
+	traits[] += {"explosiveSpecialist"};
 	sidearmWeapon[] = {"ACE_VMM3"};
 	items[] += {
-		"ACE_wirecutter",
-		"ACE_DefusalKit",
-		"ACE_EntrenchingTool"
-	};
-	backpackItems[] = {
-		"ToolKit",
-		LIST_8("APERSMine_Range_Mag"),
-		"ATMine_Range_Mag"
+		"ACE_Clacker",
+		"ACE_DefusalKit"
 	};
 };
 

--- a/ARCMT.vr/mission.sqm
+++ b/ARCMT.vr/mission.sqm
@@ -12,7 +12,7 @@ class EditorData
 	};
 	class LayerIndexProvider
 	{
-		nextID=62;
+		nextID=72;
 	};
 	class Camera
 	{
@@ -19589,7 +19589,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[""x\tmf\addons\orbat\textures\gray_mortar.paa"",""MTR"",""x\tmf\addons\orbat\textures\modif_o.paa"",14]";
+											value="[""x\tmf\addons\orbat\textures\gray_mortar.paa"",""MTR"",""x\tmf\addons\orbat\textures\modif_o.paa"",11]";
 										};
 									};
 								};
@@ -20919,7 +20919,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[""x\tmf\addons\orbat\textures\gray_engineer.paa"",""ENG"",""x\tmf\addons\orbat\textures\modif_o.paa"",11]";
+											value="[""x\tmf\addons\orbat\textures\gray_logistics.paa"",""LOGI"",""x\tmf\addons\orbat\textures\modif_o.paa"",14]";
 										};
 									};
 								};
@@ -47006,7 +47006,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[""x\tmf\addons\orbat\textures\gray_sf.paa"",""SN"","""",23]";
+											value="[""x\tmf\addons\orbat\textures\gray_sf.paa"",""SN"","""",24]";
 										};
 									};
 								};
@@ -47873,7 +47873,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[""x\tmf\addons\orbat\textures\gray_engineer.paa"",""ENG"",""x\tmf\addons\orbat\textures\modif_o.paa"",7]";
+											value="[""x\tmf\addons\orbat\textures\gray_logistics.paa"",""LOGI"",""x\tmf\addons\orbat\textures\modif_o.paa"",23]";
 										};
 									};
 								};
@@ -74075,7 +74075,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[""x\tmf\addons\orbat\textures\gray_sf.paa"",""SN"","""",15]";
+											value="[""x\tmf\addons\orbat\textures\gray_sf.paa"",""SN"","""",16]";
 										};
 									};
 								};
@@ -74942,7 +74942,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[""x\tmf\addons\orbat\textures\gray_engineer.paa"",""ENG"",""x\tmf\addons\orbat\textures\modif_o.paa"",8]";
+											value="[""x\tmf\addons\orbat\textures\gray_logistics.paa"",""LOGI"",""x\tmf\addons\orbat\textures\modif_o.paa"",15]";
 										};
 									};
 								};

--- a/ARCMT.vr/mission.sqm
+++ b/ARCMT.vr/mission.sqm
@@ -8,28 +8,46 @@ class EditorData
 	toggles=1;
 	class ItemIDProvider
 	{
-		nextID=1612;
+		nextID=1624;
 	};
 	class LayerIndexProvider
 	{
-		nextID=32;
+		nextID=62;
 	};
 	class Camera
 	{
-		pos[]={65.15416,30.986034,-12.08567};
-		dir[]={-0.29276931,-0.54829854,0.78336138};
-		up[]={-0.19195062,0.83628267,0.5136013};
-		aside[]={0.9367184,0,0.35008416};
+		pos[]={46.583649,31.804901,39.070232};
+		dir[]={0.006647611,-0.90474367,0.42598596};
+		up[]={0.014116336,0.42590228,0.90464789};
+		aside[]={0.99990445,-4.9117079e-007,-0.015602903};
 	};
 };
 binarizationWanted=0;
-sourceName="ARCMT_DEV";
+sourceName="ARCMT";
 addons[]=
 {
 	"A3_Characters_F",
 	"A3_Characters_F_Mark",
+	"A3_Weapons_F_Rifles_MX",
+	"A3_Sounds_F",
+	"A3_Sounds_F_Enoch",
+	"ace_realisticnames",
+	"ace_scopes",
+	"ace_ai",
+	"ace_ballistics",
+	"A3_Weapons_F_Acc",
+	"ace_laserpointer",
+	"A3_Weapons_F",
+	"ace_smallarms",
+	"ace_csw",
+	"ace_vector",
+	"acre_main",
+	"ace_medical_treatment",
+	"ace_trenches",
+	"ace_mk6mortar",
+	"ace_maptools",
+	"ace_hearing",
 	"ace_explosives",
-	"A3_Characters_F_Orange",
 	"ace_nouniformrestrictions",
 	"ace_gforces",
 	"ace_parachute",
@@ -42,7 +60,7 @@ class AddonsMetaData
 {
 	class List
 	{
-		items=10;
+		items=25;
 		class Item0
 		{
 			className="A3_Characters_F";
@@ -59,54 +77,159 @@ class AddonsMetaData
 		};
 		class Item2
 		{
+			className="A3_Weapons_F";
+			name="Arma 3 Alpha - Weapons and Accessories";
+			author="Bohemia Interactive";
+			url="https://www.arma3.com";
+		};
+		class Item3
+		{
+			className="A3_Sounds_F";
+			name="Arma 3 - Sound Effects";
+			author="Bohemia Interactive";
+			url="https://www.arma3.com";
+		};
+		class Item4
+		{
+			className="A3_Sounds_F_Enoch";
+			name="Arma 3 Contact Platform - Sound Effects";
+			author="Bohemia Interactive";
+			url="https://www.arma3.com";
+		};
+		class Item5
+		{
+			className="ace_scopes";
+			name="ACE3 - Scopes";
+			author="ACE-Team";
+			url="http://ace3mod.com/";
+		};
+		class Item6
+		{
+			className="ace_ai";
+			name="ACE3 - AI";
+			author="ACE-Team";
+			url="http://ace3mod.com/";
+		};
+		class Item7
+		{
+			className="ace_ballistics";
+			name="ACE3 - Ballistics";
+			author="ACE-Team";
+			url="http://ace3mod.com/";
+		};
+		class Item8
+		{
+			className="ace_laserpointer";
+			name="ACE3 - Laser Pointer";
+			author="ACE-Team";
+			url="http://ace3mod.com/";
+		};
+		class Item9
+		{
+			className="ace_smallarms";
+			name="ACE3 - Small Arms";
+			author="ACE-Team";
+			url="http://ace3mod.com/";
+		};
+		class Item10
+		{
+			className="ace_csw";
+			name="ACE3 - Crew-Served Weapons";
+			author="ACE-Team";
+			url="http://ace3mod.com/";
+		};
+		class Item11
+		{
+			className="ace_vector";
+			name="ACE3 - Vector";
+			author="ACE-Team";
+			url="http://ace3mod.com/";
+		};
+		class Item12
+		{
+			className="acre_main";
+			name="ACRE2 - Main";
+			author="ACRE2Team";
+			url="https://github.com/IDI-Systems/acre2";
+		};
+		class Item13
+		{
+			className="ace_medical_treatment";
+			name="ACE3 - Medical Treatment";
+			author="ACE-Team";
+			url="http://ace3mod.com/";
+		};
+		class Item14
+		{
+			className="ace_trenches";
+			name="ACE3 - Trenches";
+			author="ACE-Team";
+			url="http://ace3mod.com/";
+		};
+		class Item15
+		{
+			className="ace_mk6mortar";
+			name="ACE3 - Mk6 Mortar";
+			author="ACE-Team";
+			url="http://ace3mod.com/";
+		};
+		class Item16
+		{
+			className="ace_maptools";
+			name="ACE3 - Map Tools";
+			author="ACE-Team";
+			url="http://ace3mod.com/";
+		};
+		class Item17
+		{
+			className="ace_hearing";
+			name="ACE3 - Hearing";
+			author="ACE-Team";
+			url="http://ace3mod.com/";
+		};
+		class Item18
+		{
 			className="ace_explosives";
 			name="ACE3 - Explosives";
 			author="ACE-Team";
 			url="http://ace3mod.com/";
 		};
-		class Item3
-		{
-			className="A3_Characters_F_Orange";
-			name="Arma 3 Orange - Characters and Clothing";
-			author="Bohemia Interactive";
-			url="https://www.arma3.com";
-		};
-		class Item4
+		class Item19
 		{
 			className="ace_nouniformrestrictions";
 			name="ACE3 - No Uniform Restrictions";
 			author="ACE-Team";
 			url="http://ace3mod.com/";
 		};
-		class Item5
+		class Item20
 		{
 			className="ace_parachute";
 			name="ACE3 - Parachute";
 			author="ACE-Team";
 			url="http://ace3mod.com/";
 		};
-		class Item6
+		class Item21
 		{
 			className="A3_Modules_F_Curator";
 			name="Arma 3 Zeus Update - Scripted Modules";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item7
+		class Item22
 		{
 			className="TMF_safestart";
 			name="TMF: Safestart";
 			author="Head";
 			url="http://www.teamonetactical.com";
 		};
-		class Item8
+		class Item23
 		{
 			className="TMF_spectator";
 			name="TMF: Spectator";
 			author="Head";
 			url="http://www.teamonetactical.com";
 		};
-		class Item9
+		class Item24
 		{
 			className="A3_Data_F_Curator";
 			name="Arma 3 Zeus Update - Main Configuration";
@@ -122,6 +245,10 @@ class DynamicSimulation
 		Vehicle=1000;
 		Group=1000;
 	};
+};
+dlcs[]=
+{
+	"Mark"
 };
 randomSeed=652147;
 class ScenarioData
@@ -404,6 +531,25 @@ class CustomAttributes
 		name="Scenario";
 		class Attribute0
 		{
+			property="cba_settings_hasSettingsFile";
+			expression="false";
+			class Value
+			{
+				class data
+				{
+					class type
+					{
+						type[]=
+						{
+							"BOOL"
+						};
+					};
+					value=1;
+				};
+			};
+		};
+		class Attribute1
+		{
 			property="arc_misc_isTemplate";
 			expression="false";
 			class Value
@@ -421,7 +567,7 @@ class CustomAttributes
 				};
 			};
 		};
-		nAttributes=1;
+		nAttributes=2;
 	};
 };
 class Mission
@@ -484,8 +630,8 @@ class Mission
 									class Attributes
 									{
 										rank="LIEUTENANT";
-										name="NATO_HQ_CO";
-										description="Platoon leader@NATO HQ";
+										name="BLU_HQ_CO";
+										description="Platoon leader@BLUFOR HQ";
 										isPlayer=1;
 										isPlayable=1;
 									};
@@ -527,7 +673,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -622,7 +768,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""co"",""blu_f"",true]";
+													value="[""co"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -660,8 +806,8 @@ class Mission
 									class Attributes
 									{
 										rank="SERGEANT";
-										name="NATO_HQ_SGT";
-										description="Platoon Sergeant@NATO HQ";
+										name="BLU_HQ_SGT";
+										description="Platoon Sergeant@BLUFOR HQ";
 										isPlayable=1;
 									};
 									id=69;
@@ -702,7 +848,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -797,7 +943,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""sl"",""blu_f"",true]";
+													value="[""sl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -835,8 +981,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="NATO_HQ_FAC";
-										description="Forward Air Controller@NATO HQ";
+										name="BLU_HQ_FAC";
+										description="Forward Air Controller@BLUFOR HQ";
 										isPlayable=1;
 									};
 									id=71;
@@ -877,7 +1023,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -972,7 +1118,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""fac"",""blu_f"",true]";
+													value="[""fac"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -1010,8 +1156,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="NATO_HQ_UAV";
-										description="UAV Operator@NATO HQ";
+										name="BLU_HQ_UAV";
+										description="UAV Operator@BLUFOR HQ";
 										isPlayable=1;
 									};
 									id=1599;
@@ -1039,6 +1185,25 @@ class Mission
 										};
 										class Attribute1
 										{
+											property="TMF_assignGear_faction";
+											expression="false";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"STRING"
+														};
+													};
+													value="example_loadout";
+												};
+											};
+										};
+										class Attribute2
+										{
 											property="TMF_assignGear_enabled";
 											expression="false";
 											class Value
@@ -1056,7 +1221,7 @@ class Mission
 												};
 											};
 										};
-										class Attribute2
+										class Attribute3
 										{
 											property="TMF_Channellist";
 											expression="_this setVariable ['TMF_Channellist',_value,true];";
@@ -1075,7 +1240,7 @@ class Mission
 												};
 											};
 										};
-										class Attribute3
+										class Attribute4
 										{
 											property="pitch";
 											expression="_this setpitch _value;";
@@ -1094,7 +1259,7 @@ class Mission
 												};
 											};
 										};
-										class Attribute4
+										class Attribute5
 										{
 											property="speaker";
 											expression="_this setspeaker _value;";
@@ -1113,7 +1278,7 @@ class Mission
 												};
 											};
 										};
-										class Attribute5
+										class Attribute6
 										{
 											property="TMF_assignGear_full";
 											expression="[_this,  _value] call TMF_assignGear_fnc_helper";
@@ -1128,11 +1293,11 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""UAV"",""blu_f"",true]";
+													value="[""UAV"",""example_loadout"",true]";
 												};
 											};
 										};
-										class Attribute6
+										class Attribute7
 										{
 											property="TMF_assignGear_role";
 											expression="false";
@@ -1151,7 +1316,7 @@ class Mission
 												};
 											};
 										};
-										nAttributes=7;
+										nAttributes=8;
 									};
 								};
 								class Item4
@@ -1165,8 +1330,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_HQ_D";
-										description="Driver@NATO HQ";
+										name="BLU_HQ_D";
+										description="Driver@BLUFOR HQ";
 										isPlayable=1;
 									};
 									id=1600;
@@ -1174,25 +1339,6 @@ class Mission
 									class CustomAttributes
 									{
 										class Attribute0
-										{
-											property="TMF_assignGear_full";
-											expression="[_this,  _value] call TMF_assignGear_fnc_helper";
-											class Value
-											{
-												class data
-												{
-													class type
-													{
-														type[]=
-														{
-															"STRING"
-														};
-													};
-													value="[""r"",""blu_f"",true]";
-												};
-											};
-										};
-										class Attribute1
 										{
 											property="TMF_SpecialistMarker";
 											expression="_this setVariable ['TMF_SpecialistMarker',_value,true];";
@@ -1211,64 +1357,26 @@ class Mission
 												};
 											};
 										};
+										class Attribute1
+										{
+											property="TMF_assignGear_faction";
+											expression="false";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"STRING"
+														};
+													};
+													value="example_loadout";
+												};
+											};
+										};
 										class Attribute2
-										{
-											property="speaker";
-											expression="_this setspeaker _value;";
-											class Value
-											{
-												class data
-												{
-													class type
-													{
-														type[]=
-														{
-															"STRING"
-														};
-													};
-													value="Male02ENG";
-												};
-											};
-										};
-										class Attribute3
-										{
-											property="pitch";
-											expression="_this setpitch _value;";
-											class Value
-											{
-												class data
-												{
-													class type
-													{
-														type[]=
-														{
-															"SCALAR"
-														};
-													};
-													value=0.98000002;
-												};
-											};
-										};
-										class Attribute4
-										{
-											property="TMF_Channellist";
-											expression="_this setVariable ['TMF_Channellist',_value,true];";
-											class Value
-											{
-												class data
-												{
-													class type
-													{
-														type[]=
-														{
-															"STRING"
-														};
-													};
-													value="[]";
-												};
-											};
-										};
-										class Attribute5
 										{
 											property="TMF_assignGear_enabled";
 											expression="false";
@@ -1287,13 +1395,89 @@ class Mission
 												};
 											};
 										};
-										nAttributes=6;
+										class Attribute3
+										{
+											property="TMF_Channellist";
+											expression="_this setVariable ['TMF_Channellist',_value,true];";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"STRING"
+														};
+													};
+													value="[]";
+												};
+											};
+										};
+										class Attribute4
+										{
+											property="pitch";
+											expression="_this setpitch _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"SCALAR"
+														};
+													};
+													value=0.98000002;
+												};
+											};
+										};
+										class Attribute5
+										{
+											property="speaker";
+											expression="_this setspeaker _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"STRING"
+														};
+													};
+													value="Male02ENG";
+												};
+											};
+										};
+										class Attribute6
+										{
+											property="TMF_assignGear_full";
+											expression="[_this,  _value] call TMF_assignGear_fnc_helper";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"STRING"
+														};
+													};
+													value="[""r"",""example_loadout"",true]";
+												};
+											};
+										};
+										nAttributes=7;
 									};
 								};
 							};
 							class Attributes
 							{
-								name="NATO_HQ_GRP";
+								name="BLU_HQ_GRP";
 							};
 							id=67;
 							class CustomAttributes
@@ -1339,7 +1523,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -1351,7 +1535,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="NATO HQ";
+											value="BLUFOR HQ";
 										};
 									};
 								};
@@ -1415,8 +1599,8 @@ class Mission
 									class Attributes
 									{
 										rank="SERGEANT";
-										name="NATO_ASL_SL";
-										description="Squad Leader@NATO ASL";
+										name="BLU_ASL_SL";
+										description="Squad Leader@BLUFOR ASL";
 										isPlayable=1;
 									};
 									id=75;
@@ -1457,7 +1641,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -1552,7 +1736,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""sl"",""blu_f"",true]";
+													value="[""sl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -1590,8 +1774,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="NATO_ASL_M";
-										description="Medic@NATO ASL";
+										name="BLU_ASL_M";
+										description="Medic@BLUFOR ASL";
 										isPlayable=1;
 									};
 									id=76;
@@ -1632,7 +1816,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -1727,7 +1911,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""m"",""blu_f"",true]";
+													value="[""m"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -1756,7 +1940,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="NATO_ASL_GRP";
+								name="BLU_ASL_GRP";
 							};
 							id=74;
 							class CustomAttributes
@@ -1802,7 +1986,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -1814,7 +1998,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="NATO ASL";
+											value="BLUFOR ASL";
 										};
 									};
 								};
@@ -1878,8 +2062,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="NATO_A1_FTL";
-										description="Fireteam Leader@NATO A1";
+										name="BLU_A1_FTL";
+										description="Fireteam Leader@BLUFOR A1";
 										isPlayable=1;
 									};
 									id=78;
@@ -1920,7 +2104,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -2015,7 +2199,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ftl"",""blu_f"",true]";
+													value="[""ftl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -2052,8 +2236,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_A1_AR";
-										description="Autorifleman@NATO A1";
+										name="BLU_A1_AR";
+										description="Autorifleman@BLUFOR A1";
 										isPlayable=1;
 									};
 									id=79;
@@ -2094,7 +2278,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -2170,7 +2354,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ar"",""blu_f"",true]";
+													value="[""ar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -2207,8 +2391,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_A1_AAR";
-										description="Asst. Autorifleman@NATO A1";
+										name="BLU_A1_AAR";
+										description="Asst. Autorifleman@BLUFOR A1";
 										isPlayable=1;
 									};
 									id=80;
@@ -2249,7 +2433,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -2325,7 +2509,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""aar"",""blu_f"",true]";
+													value="[""aar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -2362,8 +2546,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_A1_RAT";
-										description="Rifleman (AT)@NATO A1";
+										name="BLU_A1_RAT";
+										description="Rifleman (AT)@BLUFOR A1";
 										isPlayable=1;
 									};
 									id=81;
@@ -2404,7 +2588,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -2480,7 +2664,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""rat"",""blu_f"",true]";
+													value="[""rat"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -2517,8 +2701,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_A1_R";
-										description="Rifleman@NATO A1";
+										name="BLU_A1_R";
+										description="Rifleman@BLUFOR A1";
 										isPlayable=1;
 									};
 									id=82;
@@ -2540,7 +2724,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""blu_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -2616,7 +2800,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -2653,8 +2837,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_A1_CLS";
-										description="Rifleman (CLS)@NATO A1";
+										name="BLU_A1_CLS";
+										description="Rifleman (CLS)@BLUFOR A1";
 										isPlayable=1;
 									};
 									id=83;
@@ -2695,7 +2879,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -2771,7 +2955,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""cls"",""blu_f"",true]";
+													value="[""cls"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -2800,7 +2984,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="NATO_A1_GRP";
+								name="BLU_A1_GRP";
 							};
 							id=77;
 							class CustomAttributes
@@ -2846,7 +3030,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -2858,7 +3042,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="NATO A1";
+											value="BLUFOR A1";
 										};
 									};
 								};
@@ -2922,8 +3106,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="NATO_A2_FTL";
-										description="Fireteam Leader@NATO A2";
+										name="BLU_A2_FTL";
+										description="Fireteam Leader@BLUFOR A2";
 										isPlayable=1;
 									};
 									id=89;
@@ -2964,7 +3148,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -3059,7 +3243,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ftl"",""blu_f"",true]";
+													value="[""ftl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -3096,8 +3280,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_A2_AR";
-										description="Autorifleman@NATO A2";
+										name="BLU_A2_AR";
+										description="Autorifleman@BLUFOR A2";
 										isPlayable=1;
 									};
 									id=90;
@@ -3138,7 +3322,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -3214,7 +3398,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ar"",""blu_f"",true]";
+													value="[""ar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -3251,8 +3435,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_A2_AAR";
-										description="Asst. Autorifleman@NATO A2";
+										name="BLU_A2_AAR";
+										description="Asst. Autorifleman@BLUFOR A2";
 										isPlayable=1;
 									};
 									id=91;
@@ -3293,7 +3477,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -3369,7 +3553,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""aar"",""blu_f"",true]";
+													value="[""aar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -3406,8 +3590,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_A2_RAT";
-										description="Rifleman (AT)@NATO A2";
+										name="BLU_A2_RAT";
+										description="Rifleman (AT)@BLUFOR A2";
 										isPlayable=1;
 									};
 									id=92;
@@ -3448,7 +3632,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -3524,7 +3708,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""rat"",""blu_f"",true]";
+													value="[""rat"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -3561,8 +3745,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_A2_R";
-										description="Rifleman@NATO A2";
+										name="BLU_A2_R";
+										description="Rifleman@BLUFOR A2";
 										isPlayable=1;
 									};
 									id=93;
@@ -3584,7 +3768,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""blu_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -3660,7 +3844,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -3697,8 +3881,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_A2_CLS";
-										description="Rifleman (CLS)@NATO A2";
+										name="BLU_A2_CLS";
+										description="Rifleman (CLS)@BLUFOR A2";
 										isPlayable=1;
 									};
 									id=94;
@@ -3739,7 +3923,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -3815,7 +3999,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""cls"",""blu_f"",true]";
+													value="[""cls"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -3844,7 +4028,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="NATO_A2_GRP";
+								name="BLU_A2_GRP";
 							};
 							id=88;
 							class CustomAttributes
@@ -3890,7 +4074,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -3902,7 +4086,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="NATO A2";
+											value="BLUFOR A2";
 										};
 									};
 								};
@@ -3966,8 +4150,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="NATO_A3_FTL";
-										description="Fireteam Leader@NATO A3";
+										name="BLU_A3_FTL";
+										description="Fireteam Leader@BLUFOR A3";
 										isPlayable=1;
 									};
 									id=100;
@@ -4008,7 +4192,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -4103,7 +4287,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ftl"",""blu_f"",true]";
+													value="[""ftl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -4140,8 +4324,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_A3_AR";
-										description="Autorifleman@NATO A3";
+										name="BLU_A3_AR";
+										description="Autorifleman@BLUFOR A3";
 										isPlayable=1;
 									};
 									id=101;
@@ -4182,7 +4366,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -4258,7 +4442,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ar"",""blu_f"",true]";
+													value="[""ar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -4295,8 +4479,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_A3_AAR";
-										description="Asst. Autorifleman@NATO A3";
+										name="BLU_A3_AAR";
+										description="Asst. Autorifleman@BLUFOR A3";
 										isPlayable=1;
 									};
 									id=102;
@@ -4337,7 +4521,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -4413,7 +4597,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""aar"",""blu_f"",true]";
+													value="[""aar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -4450,8 +4634,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_A3_RAT";
-										description="Rifleman (AT)@NATO A3";
+										name="BLU_A3_RAT";
+										description="Rifleman (AT)@BLUFOR A3";
 										isPlayable=1;
 									};
 									id=103;
@@ -4492,7 +4676,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -4568,7 +4752,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""rat"",""blu_f"",true]";
+													value="[""rat"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -4605,8 +4789,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_A3_R";
-										description="Rifleman@NATO A3";
+										name="BLU_A3_R";
+										description="Rifleman@BLUFOR A3";
 										isPlayable=1;
 									};
 									id=104;
@@ -4628,7 +4812,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""blu_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -4704,7 +4888,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -4741,8 +4925,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_A3_CLS";
-										description="Rifleman (CLS)@NATO A3";
+										name="BLU_A3_CLS";
+										description="Rifleman (CLS)@BLUFOR A3";
 										isPlayable=1;
 									};
 									id=105;
@@ -4783,7 +4967,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -4859,7 +5043,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""cls"",""blu_f"",true]";
+													value="[""cls"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -4888,7 +5072,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="NATO_A3_GRP";
+								name="BLU_A3_GRP";
 							};
 							id=99;
 							class CustomAttributes
@@ -4934,7 +5118,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -4946,7 +5130,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="NATO A3";
+											value="BLUFOR A3";
 										};
 									};
 								};
@@ -5010,8 +5194,8 @@ class Mission
 									class Attributes
 									{
 										rank="SERGEANT";
-										name="NATO_BSL_SL";
-										description="Squad Leader@NATO BSL";
+										name="BLU_BSL_SL";
+										description="Squad Leader@BLUFOR BSL";
 										isPlayable=1;
 									};
 									id=111;
@@ -5052,7 +5236,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -5147,7 +5331,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""sl"",""blu_f"",true]";
+													value="[""sl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -5185,8 +5369,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="NATO_BSL_M";
-										description="Medic@NATO BSL";
+										name="BLU_BSL_M";
+										description="Medic@BLUFOR BSL";
 										isPlayable=1;
 									};
 									id=112;
@@ -5227,7 +5411,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -5322,7 +5506,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""m"",""blu_f"",true]";
+													value="[""m"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -5351,7 +5535,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="NATO_BSL_GRP";
+								name="BLU_BSL_GRP";
 							};
 							id=110;
 							class CustomAttributes
@@ -5397,7 +5581,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -5409,7 +5593,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="NATO BSL";
+											value="BLUFOR BSL";
 										};
 									};
 								};
@@ -5473,8 +5657,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="NATO_B1_FTL";
-										description="Fireteam Leader@NATO B1";
+										name="BLU_B1_FTL";
+										description="Fireteam Leader@BLUFOR B1";
 										isPlayable=1;
 									};
 									id=114;
@@ -5515,7 +5699,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -5610,7 +5794,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ftl"",""blu_f"",true]";
+													value="[""ftl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -5647,8 +5831,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_B1_AR";
-										description="Autorifleman@NATO B1";
+										name="BLU_B1_AR";
+										description="Autorifleman@BLUFOR B1";
 										isPlayable=1;
 									};
 									id=115;
@@ -5689,7 +5873,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -5765,7 +5949,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ar"",""blu_f"",true]";
+													value="[""ar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -5802,8 +5986,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_B1_AAR";
-										description="Asst. Autorifleman@NATO B1";
+										name="BLU_B1_AAR";
+										description="Asst. Autorifleman@BLUFOR B1";
 										isPlayable=1;
 									};
 									id=116;
@@ -5844,7 +6028,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -5920,7 +6104,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""aar"",""blu_f"",true]";
+													value="[""aar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -5957,8 +6141,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_B1_RAT";
-										description="Rifleman (AT)@NATO B1";
+										name="BLU_B1_RAT";
+										description="Rifleman (AT)@BLUFOR B1";
 										isPlayable=1;
 									};
 									id=117;
@@ -5999,7 +6183,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -6075,7 +6259,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""rat"",""blu_f"",true]";
+													value="[""rat"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -6112,8 +6296,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_B1_R";
-										description="Rifleman@NATO B1";
+										name="BLU_B1_R";
+										description="Rifleman@BLUFOR B1";
 										isPlayable=1;
 									};
 									id=118;
@@ -6135,7 +6319,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""blu_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -6211,7 +6395,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -6248,8 +6432,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_B1_CLS";
-										description="Rifleman (CLS)@NATO B1";
+										name="BLU_B1_CLS";
+										description="Rifleman (CLS)@BLUFOR B1";
 										isPlayable=1;
 									};
 									id=119;
@@ -6290,7 +6474,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -6366,7 +6550,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""cls"",""blu_f"",true]";
+													value="[""cls"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -6395,7 +6579,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="NATO_B1_GRP";
+								name="BLU_B1_GRP";
 							};
 							id=113;
 							class CustomAttributes
@@ -6441,7 +6625,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -6453,7 +6637,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="NATO B1";
+											value="BLUFOR B1";
 										};
 									};
 								};
@@ -6517,8 +6701,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="NATO_B2_FTL";
-										description="Fireteam Leader@NATO B2";
+										name="BLU_B2_FTL";
+										description="Fireteam Leader@BLUFOR B2";
 										isPlayable=1;
 									};
 									id=125;
@@ -6559,7 +6743,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -6654,7 +6838,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ftl"",""blu_f"",true]";
+													value="[""ftl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -6691,8 +6875,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_B2_AR";
-										description="Autorifleman@NATO B2";
+										name="BLU_B2_AR";
+										description="Autorifleman@BLUFOR B2";
 										isPlayable=1;
 									};
 									id=126;
@@ -6733,7 +6917,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -6809,7 +6993,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ar"",""blu_f"",true]";
+													value="[""ar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -6846,8 +7030,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_B2_AAR";
-										description="Asst. Autorifleman@NATO B2";
+										name="BLU_B2_AAR";
+										description="Asst. Autorifleman@BLUFOR B2";
 										isPlayable=1;
 									};
 									id=127;
@@ -6888,7 +7072,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -6964,7 +7148,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""aar"",""blu_f"",true]";
+													value="[""aar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -7001,8 +7185,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_B2_RAT";
-										description="Rifleman (AT)@NATO B2";
+										name="BLU_B2_RAT";
+										description="Rifleman (AT)@BLUFOR B2";
 										isPlayable=1;
 									};
 									id=128;
@@ -7043,7 +7227,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -7119,7 +7303,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""rat"",""blu_f"",true]";
+													value="[""rat"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -7156,8 +7340,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_B2_R";
-										description="Rifleman@NATO B2";
+										name="BLU_B2_R";
+										description="Rifleman@BLUFOR B2";
 										isPlayable=1;
 									};
 									id=129;
@@ -7179,7 +7363,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""blu_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -7255,7 +7439,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -7292,8 +7476,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_B2_CLS";
-										description="Rifleman (CLS)@NATO B2";
+										name="BLU_B2_CLS";
+										description="Rifleman (CLS)@BLUFOR B2";
 										isPlayable=1;
 									};
 									id=130;
@@ -7334,7 +7518,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -7410,7 +7594,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""cls"",""blu_f"",true]";
+													value="[""cls"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -7439,7 +7623,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="NATO_B2_GRP";
+								name="BLU_B2_GRP";
 							};
 							id=124;
 							class CustomAttributes
@@ -7485,7 +7669,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -7497,7 +7681,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="NATO B2";
+											value="BLUFOR B2";
 										};
 									};
 								};
@@ -7561,8 +7745,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="NATO_B3_FTL";
-										description="Fireteam Leader@NATO B3";
+										name="BLU_B3_FTL";
+										description="Fireteam Leader@BLUFOR B3";
 										isPlayable=1;
 									};
 									id=136;
@@ -7603,7 +7787,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -7698,7 +7882,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ftl"",""blu_f"",true]";
+													value="[""ftl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -7735,8 +7919,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_B3_AR";
-										description="Autorifleman@NATO B3";
+										name="BLU_B3_AR";
+										description="Autorifleman@BLUFOR B3";
 										isPlayable=1;
 									};
 									id=137;
@@ -7777,7 +7961,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -7853,7 +8037,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ar"",""blu_f"",true]";
+													value="[""ar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -7890,8 +8074,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_B3_AAR";
-										description="Asst. Autorifleman@NATO B3";
+										name="BLU_B3_AAR";
+										description="Asst. Autorifleman@BLUFOR B3";
 										isPlayable=1;
 									};
 									id=138;
@@ -7932,7 +8116,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -8008,7 +8192,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""aar"",""blu_f"",true]";
+													value="[""aar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -8045,8 +8229,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_B3_RAT";
-										description="Rifleman (AT)@NATO B3";
+										name="BLU_B3_RAT";
+										description="Rifleman (AT)@BLUFOR B3";
 										isPlayable=1;
 									};
 									id=139;
@@ -8087,7 +8271,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -8163,7 +8347,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""rat"",""blu_f"",true]";
+													value="[""rat"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -8200,8 +8384,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_B3_R";
-										description="Rifleman@NATO B3";
+										name="BLU_B3_R";
+										description="Rifleman@BLUFOR B3";
 										isPlayable=1;
 									};
 									id=140;
@@ -8223,7 +8407,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""blu_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -8299,7 +8483,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -8336,8 +8520,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_B3_CLS";
-										description="Rifleman (CLS)@NATO B3";
+										name="BLU_B3_CLS";
+										description="Rifleman (CLS)@BLUFOR B3";
 										isPlayable=1;
 									};
 									id=141;
@@ -8378,7 +8562,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -8454,7 +8638,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""cls"",""blu_f"",true]";
+													value="[""cls"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -8483,7 +8667,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="NATO_B3_GRP";
+								name="BLU_B3_GRP";
 							};
 							id=135;
 							class CustomAttributes
@@ -8529,7 +8713,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -8541,7 +8725,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="NATO B3";
+											value="BLUFOR B3";
 										};
 									};
 								};
@@ -8605,8 +8789,8 @@ class Mission
 									class Attributes
 									{
 										rank="SERGEANT";
-										name="NATO_CSL_SL";
-										description="Squad Leader@NATO CSL";
+										name="BLU_CSL_SL";
+										description="Squad Leader@BLUFOR CSL";
 										isPlayable=1;
 									};
 									id=147;
@@ -8647,7 +8831,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -8742,7 +8926,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""sl"",""blu_f"",true]";
+													value="[""sl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -8780,8 +8964,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="NATO_CSL_M";
-										description="Medic@NATO CSL";
+										name="BLU_CSL_M";
+										description="Medic@BLUFOR CSL";
 										isPlayable=1;
 									};
 									id=148;
@@ -8822,7 +9006,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -8917,7 +9101,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""m"",""blu_f"",true]";
+													value="[""m"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -8946,7 +9130,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="NATO_CSL_GRP";
+								name="BLU_CSL_GRP";
 							};
 							id=146;
 							class CustomAttributes
@@ -8992,7 +9176,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -9004,7 +9188,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="NATO CSL";
+											value="BLUFOR CSL";
 										};
 									};
 								};
@@ -9068,8 +9252,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="NATO_C1_FTL";
-										description="Fireteam Leader@NATO C1";
+										name="BLU_C1_FTL";
+										description="Fireteam Leader@BLUFOR C1";
 										isPlayable=1;
 									};
 									id=150;
@@ -9110,7 +9294,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -9205,7 +9389,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ftl"",""blu_f"",true]";
+													value="[""ftl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -9242,8 +9426,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_C1_AR";
-										description="Autorifleman@NATO C1";
+										name="BLU_C1_AR";
+										description="Autorifleman@BLUFOR C1";
 										isPlayable=1;
 									};
 									id=151;
@@ -9284,7 +9468,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -9360,7 +9544,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ar"",""blu_f"",true]";
+													value="[""ar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -9397,8 +9581,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_C1_AAR";
-										description="Asst. Autorifleman@NATO C1";
+										name="BLU_C1_AAR";
+										description="Asst. Autorifleman@BLUFOR C1";
 										isPlayable=1;
 									};
 									id=152;
@@ -9439,7 +9623,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -9515,7 +9699,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""aar"",""blu_f"",true]";
+													value="[""aar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -9552,8 +9736,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_C1_RAT";
-										description="Rifleman (AT)@NATO C1";
+										name="BLU_C1_RAT";
+										description="Rifleman (AT)@BLUFOR C1";
 										isPlayable=1;
 									};
 									id=153;
@@ -9594,7 +9778,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -9670,7 +9854,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""rat"",""blu_f"",true]";
+													value="[""rat"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -9707,8 +9891,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_C1_R";
-										description="Rifleman@NATO C1";
+										name="BLU_C1_R";
+										description="Rifleman@BLUFOR C1";
 										isPlayable=1;
 									};
 									id=154;
@@ -9730,7 +9914,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""blu_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -9806,7 +9990,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -9843,8 +10027,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_C1_CLS";
-										description="Rifleman (CLS)@NATO C1";
+										name="BLU_C1_CLS";
+										description="Rifleman (CLS)@BLUFOR C1";
 										isPlayable=1;
 									};
 									id=155;
@@ -9885,7 +10069,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -9961,7 +10145,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""cls"",""blu_f"",true]";
+													value="[""cls"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -9990,7 +10174,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="NATO_C1_GRP";
+								name="BLU_C1_GRP";
 							};
 							id=149;
 							class CustomAttributes
@@ -10036,7 +10220,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -10048,7 +10232,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="NATO C1";
+											value="BLUFOR C1";
 										};
 									};
 								};
@@ -10112,8 +10296,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="NATO_C2_FTL";
-										description="Fireteam Leader@NATO C2";
+										name="BLU_C2_FTL";
+										description="Fireteam Leader@BLUFOR C2";
 										isPlayable=1;
 									};
 									id=161;
@@ -10154,7 +10338,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -10249,7 +10433,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ftl"",""blu_f"",true]";
+													value="[""ftl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -10286,8 +10470,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_C2_AR";
-										description="Autorifleman@NATO C2";
+										name="BLU_C2_AR";
+										description="Autorifleman@BLUFOR C2";
 										isPlayable=1;
 									};
 									id=162;
@@ -10328,7 +10512,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -10404,7 +10588,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ar"",""blu_f"",true]";
+													value="[""ar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -10441,8 +10625,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_C2_AAR";
-										description="Asst. Autorifleman@NATO C2";
+										name="BLU_C2_AAR";
+										description="Asst. Autorifleman@BLUFOR C2";
 										isPlayable=1;
 									};
 									id=163;
@@ -10483,7 +10667,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -10559,7 +10743,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""aar"",""blu_f"",true]";
+													value="[""aar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -10596,8 +10780,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_C2_RAT";
-										description="Rifleman (AT)@NATO C2";
+										name="BLU_C2_RAT";
+										description="Rifleman (AT)@BLUFOR C2";
 										isPlayable=1;
 									};
 									id=164;
@@ -10638,7 +10822,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -10714,7 +10898,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""rat"",""blu_f"",true]";
+													value="[""rat"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -10751,8 +10935,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_C2_R";
-										description="Rifleman@NATO C2";
+										name="BLU_C2_R";
+										description="Rifleman@BLUFOR C2";
 										isPlayable=1;
 									};
 									id=165;
@@ -10774,7 +10958,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""blu_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -10850,7 +11034,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -10887,8 +11071,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_C2_CLS";
-										description="Rifleman (CLS)@NATO C2";
+										name="BLU_C2_CLS";
+										description="Rifleman (CLS)@BLUFOR C2";
 										isPlayable=1;
 									};
 									id=166;
@@ -10929,7 +11113,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -11005,7 +11189,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""cls"",""blu_f"",true]";
+													value="[""cls"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -11034,7 +11218,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="NATO_C2_GRP";
+								name="BLU_C2_GRP";
 							};
 							id=160;
 							class CustomAttributes
@@ -11080,7 +11264,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -11092,7 +11276,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="NATO C2";
+											value="BLUFOR C2";
 										};
 									};
 								};
@@ -11156,8 +11340,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="NATO_C3_FTL";
-										description="Fireteam Leader@NATO C3";
+										name="BLU_C3_FTL";
+										description="Fireteam Leader@BLUFOR C3";
 										isPlayable=1;
 									};
 									id=172;
@@ -11198,7 +11382,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -11293,7 +11477,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ftl"",""blu_f"",true]";
+													value="[""ftl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -11330,8 +11514,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_C3_AR";
-										description="Autorifleman@NATO C3";
+										name="BLU_C3_AR";
+										description="Autorifleman@BLUFOR C3";
 										isPlayable=1;
 									};
 									id=173;
@@ -11372,7 +11556,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -11448,7 +11632,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ar"",""blu_f"",true]";
+													value="[""ar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -11485,8 +11669,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_C3_AAR";
-										description="Asst. Autorifleman@NATO C3";
+										name="BLU_C3_AAR";
+										description="Asst. Autorifleman@BLUFOR C3";
 										isPlayable=1;
 									};
 									id=174;
@@ -11527,7 +11711,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -11603,7 +11787,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""aar"",""blu_f"",true]";
+													value="[""aar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -11640,8 +11824,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_C3_RAT";
-										description="Rifleman (AT)@NATO C3";
+										name="BLU_C3_RAT";
+										description="Rifleman (AT)@BLUFOR C3";
 										isPlayable=1;
 									};
 									id=175;
@@ -11682,7 +11866,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -11758,7 +11942,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""rat"",""blu_f"",true]";
+													value="[""rat"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -11795,8 +11979,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_C3_R";
-										description="Rifleman@NATO C3";
+										name="BLU_C3_R";
+										description="Rifleman@BLUFOR C3";
 										isPlayable=1;
 									};
 									id=176;
@@ -11818,7 +12002,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""blu_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -11894,7 +12078,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -11931,8 +12115,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_C3_CLS";
-										description="Rifleman (CLS)@NATO C3";
+										name="BLU_C3_CLS";
+										description="Rifleman (CLS)@BLUFOR C3";
 										isPlayable=1;
 									};
 									id=177;
@@ -11973,7 +12157,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -12049,7 +12233,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""cls"",""blu_f"",true]";
+													value="[""cls"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -12078,7 +12262,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="NATO_C3_GRP";
+								name="BLU_C3_GRP";
 							};
 							id=171;
 							class CustomAttributes
@@ -12124,7 +12308,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -12136,7 +12320,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="NATO C3";
+											value="BLUFOR C3";
 										};
 									};
 								};
@@ -12200,8 +12384,8 @@ class Mission
 									class Attributes
 									{
 										rank="SERGEANT";
-										name="NATO_WSL_SL";
-										description="Squad Leader@NATO WSL";
+										name="BLU_WSL_SL";
+										description="Squad Leader@BLUFOR WSL";
 										isPlayable=1;
 									};
 									id=183;
@@ -12242,7 +12426,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -12337,7 +12521,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""sl"",""blu_f"",true]";
+													value="[""sl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -12375,8 +12559,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="NATO_WSL_M";
-										description="Medic@NATO WSL";
+										name="BLU_WSL_M";
+										description="Medic@BLUFOR WSL";
 										isPlayable=1;
 									};
 									id=185;
@@ -12417,7 +12601,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -12512,7 +12696,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""m"",""blu_f"",true]";
+													value="[""m"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -12541,7 +12725,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="NATO_WSL_GRP";
+								name="BLU_WSL_GRP";
 							};
 							id=182;
 							class CustomAttributes
@@ -12561,7 +12745,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -12587,7 +12771,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -12599,7 +12783,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="NATO WSL";
+											value="BLUFOR WSL";
 										};
 									};
 								};
@@ -12663,8 +12847,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="NATO_MMG1_MMGTL";
-										description="Team Leader@NATO MMG1";
+										name="BLU_MMG1_MMGTL";
+										description="Team Leader@BLUFOR MMG1";
 										isPlayable=1;
 									};
 									id=189;
@@ -12705,7 +12889,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -12819,7 +13003,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""mmgtl"",""blu_f"",true]";
+													value="[""mmgtl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -12856,8 +13040,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_MMG1_MMGG";
-										description="Gunner@NATO MMG1";
+										name="BLU_MMG1_MMGG";
+										description="Gunner@BLUFOR MMG1";
 										isPlayable=1;
 									};
 									id=190;
@@ -12898,7 +13082,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -13012,7 +13196,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""mmgg"",""blu_f"",true]";
+													value="[""mmgg"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -13049,8 +13233,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_MMG1_MMGAC";
-										description="Ammocarrier@NATO MMG1";
+										name="BLU_MMG1_MMGAC";
+										description="Ammocarrier@BLUFOR MMG1";
 										isPlayable=1;
 									};
 									id=192;
@@ -13091,7 +13275,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -13205,7 +13389,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""mmgac"",""blu_f"",true]";
+													value="[""mmgac"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -13234,7 +13418,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="NATO_MMG1_GRP";
+								name="BLU_MMG1_GRP";
 							};
 							id=188;
 							class CustomAttributes
@@ -13254,7 +13438,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -13280,7 +13464,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -13292,7 +13476,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="NATO MMG1";
+											value="BLUFOR MMG1";
 										};
 									};
 								};
@@ -13356,8 +13540,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="NATO_MMG2_MMGTL";
-										description="Team Leader@NATO MMG2";
+										name="BLU_MMG2_MMGTL";
+										description="Team Leader@BLUFOR MMG2";
 										isPlayable=1;
 									};
 									id=1460;
@@ -13398,7 +13582,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -13512,7 +13696,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""mmgtl"",""blu_f"",true]";
+													value="[""mmgtl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -13549,8 +13733,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_MMG2_MMGG";
-										description="Gunner@NATO MMG2";
+										name="BLU_MMG2_MMGG";
+										description="Gunner@BLUFOR MMG2";
 										isPlayable=1;
 									};
 									id=1461;
@@ -13591,7 +13775,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -13705,7 +13889,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""mmgg"",""blu_f"",true]";
+													value="[""mmgg"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -13742,8 +13926,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_MMG2_MMGAC";
-										description="Ammocarrier@NATO MMG2";
+										name="BLU_MMG2_MMGAC";
+										description="Ammocarrier@BLUFOR MMG2";
 										isPlayable=1;
 									};
 									id=1462;
@@ -13784,7 +13968,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -13898,7 +14082,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""mmgac"",""blu_f"",true]";
+													value="[""mmgac"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -13927,7 +14111,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="NATO_MMG2_GRP";
+								name="BLU_MMG2_GRP";
 							};
 							id=1459;
 							class CustomAttributes
@@ -13947,7 +14131,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -13973,7 +14157,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -13985,7 +14169,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="NATO MMG2";
+											value="BLUFOR MMG2";
 										};
 									};
 								};
@@ -14049,8 +14233,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="NATO_HMG1_HMGTL";
-										description="Team Leader@NATO HMG1";
+										name="BLU_HMG1_HMGTL";
+										description="Team Leader@BLUFOR HMG1";
 										isPlayable=1;
 									};
 									id=1464;
@@ -14091,7 +14275,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -14205,7 +14389,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hmgtl"",""blu_f"",true]";
+													value="[""hmgtl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -14242,8 +14426,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_HMG1_HMGG";
-										description="Gunner@NATO HMG1";
+										name="BLU_HMG1_HMGG";
+										description="Gunner@BLUFOR HMG1";
 										isPlayable=1;
 									};
 									id=1465;
@@ -14284,7 +14468,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -14398,7 +14582,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hmgg"",""blu_f"",true]";
+													value="[""hmgg"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -14435,8 +14619,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_HMG1_HMGAC";
-										description="Ammocarrier@NATO HMG1";
+										name="BLU_HMG1_HMGAC";
+										description="Ammocarrier@BLUFOR HMG1";
 										isPlayable=1;
 									};
 									id=1466;
@@ -14477,7 +14661,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -14591,7 +14775,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hmgac"",""blu_f"",true]";
+													value="[""hmgac"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -14620,7 +14804,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="NATO_HMG1_GRP";
+								name="BLU_HMG1_GRP";
 							};
 							id=1463;
 							class CustomAttributes
@@ -14640,7 +14824,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -14666,7 +14850,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -14678,7 +14862,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="NATO HMG1";
+											value="BLUFOR HMG1";
 										};
 									};
 								};
@@ -14742,8 +14926,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="NATO_HMG2_HMGTL";
-										description="Team Leader@NATO HMG2";
+										name="BLU_HMG2_HMGTL";
+										description="Team Leader@BLUFOR HMG2";
 										isPlayable=1;
 									};
 									id=1476;
@@ -14784,7 +14968,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -14898,7 +15082,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hmgtl"",""blu_f"",true]";
+													value="[""hmgtl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -14935,8 +15119,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_HMG2_HMGG";
-										description="Gunner@NATO HMG2";
+										name="BLU_HMG2_HMGG";
+										description="Gunner@BLUFOR HMG2";
 										isPlayable=1;
 									};
 									id=1477;
@@ -14977,7 +15161,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -15091,7 +15275,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hmgg"",""blu_f"",true]";
+													value="[""hmgg"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -15128,8 +15312,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_HMG2_HMGAC";
-										description="Ammocarrier@NATO HMG2";
+										name="BLU_HMG2_HMGAC";
+										description="Ammocarrier@BLUFOR HMG2";
 										isPlayable=1;
 									};
 									id=1478;
@@ -15170,7 +15354,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -15303,7 +15487,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hmgac"",""blu_f"",true]";
+													value="[""hmgac"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -15332,7 +15516,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="NATO_HMG2_GRP";
+								name="BLU_HMG2_GRP";
 							};
 							id=1475;
 							class CustomAttributes
@@ -15352,7 +15536,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -15378,7 +15562,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -15390,7 +15574,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="NATO HMG2";
+											value="BLUFOR HMG2";
 										};
 									};
 								};
@@ -15454,8 +15638,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="NATO_MAT1_MATTL";
-										description="Team Leader@NATO MAT1";
+										name="BLU_MAT1_MATTL";
+										description="Team Leader@BLUFOR MAT1";
 										isPlayable=1;
 									};
 									id=210;
@@ -15496,7 +15680,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -15610,7 +15794,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""mattl"",""blu_f"",true]";
+													value="[""mattl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -15647,8 +15831,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_MAT1_MATG";
-										description="Gunner@NATO MAT1";
+										name="BLU_MAT1_MATG";
+										description="Gunner@BLUFOR MAT1";
 										isPlayable=1;
 									};
 									id=211;
@@ -15689,7 +15873,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -15803,7 +15987,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""matg"",""blu_f"",true]";
+													value="[""matg"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -15840,8 +16024,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_MAT1_MATAC";
-										description="Ammocarrier@NATO MAT1";
+										name="BLU_MAT1_MATAC";
+										description="Ammocarrier@BLUFOR MAT1";
 										isPlayable=1;
 									};
 									id=212;
@@ -15882,7 +16066,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -15996,7 +16180,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""matac"",""blu_f"",true]";
+													value="[""matac"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -16025,7 +16209,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="NATO_MAT1_GRP";
+								name="BLU_MAT1_GRP";
 							};
 							id=209;
 							class CustomAttributes
@@ -16045,7 +16229,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -16071,7 +16255,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -16083,7 +16267,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="NATO MAT1";
+											value="BLUFOR MAT1";
 										};
 									};
 								};
@@ -16147,8 +16331,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="NATO_MAT2_MATTL";
-										description="Team Leader@NATO MAT2";
+										name="BLU_MAT2_MATTL";
+										description="Team Leader@BLUFOR MAT2";
 										isPlayable=1;
 										stance="Up";
 									};
@@ -16190,7 +16374,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -16304,7 +16488,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""mattl"",""blu_f"",true]";
+													value="[""mattl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -16341,8 +16525,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_MAT2_MATG";
-										description="Gunner@NATO MAT2";
+										name="BLU_MAT2_MATG";
+										description="Gunner@BLUFOR MAT2";
 										isPlayable=1;
 									};
 									id=1457;
@@ -16383,7 +16567,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -16497,7 +16681,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""matg"",""blu_f"",true]";
+													value="[""matg"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -16534,8 +16718,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_MAT2_MATAC";
-										description="Ammocarrier@NATO MAT2";
+										name="BLU_MAT2_MATAC";
+										description="Ammocarrier@BLUFOR MAT2";
 										isPlayable=1;
 									};
 									id=1458;
@@ -16576,7 +16760,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -16690,7 +16874,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""matac"",""blu_f"",true]";
+													value="[""matac"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -16719,7 +16903,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="NATO_MAT2_GRP";
+								name="BLU_MAT2_GRP";
 							};
 							id=1455;
 							class CustomAttributes
@@ -16739,7 +16923,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -16765,7 +16949,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -16777,7 +16961,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="NATO MAT2";
+											value="BLUFOR MAT2";
 										};
 									};
 								};
@@ -16841,8 +17025,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="NATO_HAT1_HATTL";
-										description="Team Leader@NATO HAT1";
+										name="BLU_HAT1_HATTL";
+										description="Team Leader@BLUFOR HAT1";
 										isPlayable=1;
 									};
 									id=1468;
@@ -16883,7 +17067,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -16997,7 +17181,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hattl"",""blu_f"",true]";
+													value="[""hattl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -17034,8 +17218,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_HAT1_HATG";
-										description="Gunner@NATO HAT1";
+										name="BLU_HAT1_HATG";
+										description="Gunner@BLUFOR HAT1";
 										isPlayable=1;
 									};
 									id=1469;
@@ -17076,7 +17260,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -17190,7 +17374,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hatg"",""blu_f"",true]";
+													value="[""hatg"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -17227,8 +17411,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_HAT1_HATAC";
-										description="Ammocarrier@NATO HAT1";
+										name="BLU_HAT1_HATAC";
+										description="Ammocarrier@BLUFOR HAT1";
 										isPlayable=1;
 									};
 									id=1470;
@@ -17269,7 +17453,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -17383,7 +17567,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hatac"",""blu_f"",true]";
+													value="[""hatac"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -17412,7 +17596,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="NATO_HAT1_GRP";
+								name="BLU_HAT1_GRP";
 							};
 							id=1467;
 							class CustomAttributes
@@ -17432,7 +17616,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -17458,7 +17642,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -17470,7 +17654,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="NATO HAT1";
+											value="BLUFOR HAT1";
 										};
 									};
 								};
@@ -17534,8 +17718,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="NATO_HAT2_HATTL";
-										description="Team Leader@NATO HAT2";
+										name="BLU_HAT2_HATTL";
+										description="Team Leader@BLUFOR HAT2";
 										isPlayable=1;
 										stance="Up";
 									};
@@ -17577,7 +17761,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -17691,7 +17875,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hattl"",""blu_f"",true]";
+													value="[""hattl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -17728,8 +17912,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_HAT2_HATG";
-										description="Gunner@NATO HAT2";
+										name="BLU_HAT2_HATG";
+										description="Gunner@BLUFOR HAT2";
 										isPlayable=1;
 									};
 									id=1473;
@@ -17770,7 +17954,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -17884,7 +18068,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hatg"",""blu_f"",true]";
+													value="[""hatg"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -17921,8 +18105,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_HAT2_HATAC";
-										description="Ammocarrier@NATO HAT2";
+										name="BLU_HAT2_HATAC";
+										description="Ammocarrier@BLUFOR HAT2";
 										isPlayable=1;
 									};
 									id=1474;
@@ -17963,7 +18147,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -18077,7 +18261,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hatac"",""blu_f"",true]";
+													value="[""hatac"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -18106,7 +18290,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="NATO_HAT2_GRP";
+								name="BLU_HAT2_GRP";
 							};
 							id=1471;
 							class CustomAttributes
@@ -18126,7 +18310,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -18152,7 +18336,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -18164,7 +18348,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="NATO HAT2";
+											value="BLUFOR HAT2";
 										};
 									};
 								};
@@ -18228,8 +18412,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="NATO_MANPADS_SAMAG";
-										description="Team Leader@NATO MANPADS";
+										name="BLU_MANPADS_SAMAG";
+										description="Team Leader@BLUFOR MANPADS";
 										isPlayable=1;
 									};
 									id=232;
@@ -18270,7 +18454,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -18365,7 +18549,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""samag"",""blu_f"",true]";
+													value="[""samag"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -18402,8 +18586,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_MANPADS_SAMG";
-										description="Gunner@NATO MANPADS";
+										name="BLU_MANPADS_SAMG";
+										description="Gunner@BLUFOR MANPADS";
 										isPlayable=1;
 									};
 									id=234;
@@ -18444,7 +18628,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -18558,7 +18742,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""samg"",""blu_f"",true]";
+													value="[""samg"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -18587,7 +18771,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="NATO_MANPADS_GRP";
+								name="BLU_MANPADS_GRP";
 							};
 							id=231;
 							class CustomAttributes
@@ -18607,7 +18791,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -18633,7 +18817,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -18645,7 +18829,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="NATO MANPADS";
+											value="BLUFOR MANPADS";
 										};
 									};
 								};
@@ -18709,9 +18893,136 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="NATO_MTR_MTRTL";
-										description="Team Leader@NATO MTR";
+										name="BLU_MTR_MTRTL";
+										description="Team Leader@BLUFOR MTR";
 										isPlayable=1;
+										class Inventory
+										{
+											class primaryWeapon
+											{
+												name="arifle_MXC_F";
+												optics="optic_Holosight";
+												flashlight="acc_pointer_IR";
+												class primaryMuzzleMag
+												{
+													name="30Rnd_65x39_caseless_mag";
+													ammoLeft=30;
+												};
+											};
+											class secondaryWeapon
+											{
+												name="ace_csw_carryMortarBaseplate";
+											};
+											class binocular
+											{
+												name="ACE_Vector";
+											};
+											class uniform
+											{
+												typeName="U_B_CombatUniform_mcam_vest";
+												isBackpack=0;
+												class ItemCargo
+												{
+													items=6;
+													class Item0
+													{
+														name="ACE_fieldDressing";
+														count=5;
+													};
+													class Item1
+													{
+														name="ACE_morphine";
+														count=1;
+													};
+													class Item2
+													{
+														name="ACE_tourniquet";
+														count=2;
+													};
+													class Item3
+													{
+														name="ACE_EntrenchingTool";
+														count=1;
+													};
+													class Item4
+													{
+														name="ACE_RangeTable_82mm";
+														count=1;
+													};
+													class Item5
+													{
+														name="ACE_MapTools";
+														count=1;
+													};
+												};
+											};
+											class vest
+											{
+												typeName="V_PlateCarrier1_rgr";
+												isBackpack=0;
+												class MagazineCargo
+												{
+													items=4;
+													class Item0
+													{
+														name="30Rnd_65x39_caseless_mag";
+														count=8;
+														ammoLeft=30;
+													};
+													class Item1
+													{
+														name="30Rnd_65x39_caseless_mag_Tracer";
+														count=2;
+														ammoLeft=30;
+													};
+													class Item2
+													{
+														name="HandGrenade";
+														count=2;
+														ammoLeft=1;
+													};
+													class Item3
+													{
+														name="SmokeShell";
+														count=2;
+														ammoLeft=1;
+													};
+												};
+											};
+											class backpack
+											{
+												typeName="B_Carryall_mcamo";
+												isBackpack=1;
+												class MagazineCargo
+												{
+													items=3;
+													class Item0
+													{
+														name="ACE_1Rnd_82mm_Mo_HE";
+														count=4;
+														ammoLeft=1;
+													};
+													class Item1
+													{
+														name="ACE_1Rnd_82mm_Mo_Illum";
+														count=1;
+														ammoLeft=1;
+													};
+													class Item2
+													{
+														name="ACE_1Rnd_82mm_Mo_Smoke";
+														count=1;
+														ammoLeft=1;
+													};
+												};
+											};
+											map="ItemMap";
+											compass="ItemCompass";
+											watch="ItemWatch";
+											radio="ItemRadio";
+											gps="ItemGPS";
+											headgear="H_HelmetB";
+										};
 									};
 									id=236;
 									type="B_support_AMort_F";
@@ -18751,7 +19062,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -18865,7 +19176,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""mtrtl"",""blu_f"",true]";
+													value="[""mtrtl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -18902,9 +19213,121 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_MTR_MTRG";
-										description="Gunner@NATO MTR";
+										name="BLU_MTR_MTRG";
+										description="Gunner@BLUFOR MTR";
 										isPlayable=1;
+										class Inventory
+										{
+											class primaryWeapon
+											{
+												name="arifle_MXC_F";
+												optics="optic_Holosight";
+												flashlight="acc_pointer_IR";
+												class primaryMuzzleMag
+												{
+													name="30Rnd_65x39_caseless_mag";
+													ammoLeft=30;
+												};
+											};
+											class secondaryWeapon
+											{
+												name="ace_csw_staticMortarCarry";
+											};
+											class uniform
+											{
+												typeName="U_B_CombatUniform_mcam_vest";
+												isBackpack=0;
+												class ItemCargo
+												{
+													items=4;
+													class Item0
+													{
+														name="ACE_fieldDressing";
+														count=5;
+													};
+													class Item1
+													{
+														name="ACE_morphine";
+														count=1;
+													};
+													class Item2
+													{
+														name="ACE_tourniquet";
+														count=2;
+													};
+													class Item3
+													{
+														name="ACE_EntrenchingTool";
+														count=1;
+													};
+												};
+											};
+											class vest
+											{
+												typeName="V_PlateCarrier2_rgr";
+												isBackpack=0;
+												class MagazineCargo
+												{
+													items=4;
+													class Item0
+													{
+														name="30Rnd_65x39_caseless_mag";
+														count=8;
+														ammoLeft=30;
+													};
+													class Item1
+													{
+														name="30Rnd_65x39_caseless_mag_Tracer";
+														count=2;
+														ammoLeft=30;
+													};
+													class Item2
+													{
+														name="HandGrenade";
+														count=2;
+														ammoLeft=1;
+													};
+													class Item3
+													{
+														name="SmokeShell";
+														count=2;
+														ammoLeft=1;
+													};
+												};
+											};
+											class backpack
+											{
+												typeName="B_Carryall_mcamo";
+												isBackpack=1;
+												class MagazineCargo
+												{
+													items=3;
+													class Item0
+													{
+														name="ACE_1Rnd_82mm_Mo_HE";
+														count=4;
+														ammoLeft=1;
+													};
+													class Item1
+													{
+														name="ACE_1Rnd_82mm_Mo_Illum";
+														count=1;
+														ammoLeft=1;
+													};
+													class Item2
+													{
+														name="ACE_1Rnd_82mm_Mo_Smoke";
+														count=1;
+														ammoLeft=1;
+													};
+												};
+											};
+											map="ItemMap";
+											compass="ItemCompass";
+											watch="ItemWatch";
+											radio="ItemRadio";
+											headgear="H_HelmetSpecB";
+										};
 									};
 									id=237;
 									type="B_support_Mort_F";
@@ -18944,7 +19367,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -19058,7 +19481,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""mtrg"",""blu_f"",true]";
+													value="[""mtrg"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -19095,8 +19518,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_MTR_MTRAC";
-										description="Ammocarrier@NATO MTR";
+										name="BLU_MTR_MTRAC";
+										description="Ammocarrier@BLUFOR MTR";
 										isPlayable=1;
 									};
 									id=238;
@@ -19137,7 +19560,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -19232,7 +19655,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""mtrac"",""blu_f"",true]";
+													value="[""mtrac"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -19261,7 +19684,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="NATO_MTR_GRP";
+								name="BLU_MTR_GRP";
 							};
 							id=235;
 							class CustomAttributes
@@ -19281,7 +19704,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -19307,7 +19730,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -19319,7 +19742,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="NATO MTR";
+											value="BLUFOR MTR";
 										};
 									};
 								};
@@ -19383,8 +19806,8 @@ class Mission
 									class Attributes
 									{
 										rank="LIEUTENANT";
-										name="NATO_SN_SP";
-										description="Spotter@NATO SN";
+										name="BLU_SN_SP";
+										description="Spotter@BLUFOR SN";
 										isPlayable=1;
 									};
 									id=254;
@@ -19425,7 +19848,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -19520,7 +19943,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""sp"",""blu_f"",true]";
+													value="[""sp"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -19558,8 +19981,8 @@ class Mission
 									class Attributes
 									{
 										rank="SERGEANT";
-										name="NATO_SN_SN";
-										description="Sniper@NATO SN";
+										name="BLU_SN_SN";
+										description="Sniper@BLUFOR SN";
 										isPlayable=1;
 									};
 									id=255;
@@ -19600,7 +20023,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -19714,7 +20137,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""sn"",""blu_f"",true]";
+													value="[""sn"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -19743,7 +20166,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="NATO_SN_GRP";
+								name="BLU_SN_GRP";
 							};
 							id=253;
 							class CustomAttributes
@@ -19763,7 +20186,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -19789,7 +20212,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -19801,7 +20224,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="NATO SN";
+											value="BLUFOR SN";
 										};
 									};
 								};
@@ -19861,16 +20284,16 @@ class Mission
 										position[]={44,5.0014391,28.049999};
 									};
 									side="West";
-									flags=7;
+									flags=6;
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="NATO_ENG_ENG1";
-										description="Engineer Leader (Explosives)@NATO ENG";
+										name="BLU_LOGI_LOGI1";
+										description="Team Leader@BLUFOR LOGI";
 										isPlayable=1;
 									};
-									id=249;
-									type="B_soldier_exp_F";
+									id=1612;
+									type="B_engineer_F";
 									class CustomAttributes
 									{
 										class Attribute0
@@ -19907,7 +20330,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -20002,7 +20425,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""eng"",""blu_f"",true]";
+													value="[""logi"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -20021,7 +20444,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="eng";
+													value="logi";
 												};
 											};
 										};
@@ -20036,15 +20459,15 @@ class Mission
 										position[]={43,5.0014391,27.049999};
 									};
 									side="West";
-									flags=5;
+									flags=4;
 									class Attributes
 									{
-										name="NATO_ENG_ENG2";
-										description="Engineer (Explosives)@NATO ENG";
+										name="BLU_LOGI_LOGI2";
+										description="Engineer@BLUFOR LOGI";
 										isPlayable=1;
 									};
-									id=250;
-									type="B_soldier_exp_F";
+									id=1613;
+									type="B_engineer_F";
 									class CustomAttributes
 									{
 										class Attribute0
@@ -20081,7 +20504,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -20195,7 +20618,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""eng"",""blu_f"",true]";
+													value="[""logi"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -20214,7 +20637,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="eng";
+													value="logi";
 												};
 											};
 										};
@@ -20229,15 +20652,15 @@ class Mission
 										position[]={45,5.0014391,27.049999};
 									};
 									side="West";
-									flags=5;
+									flags=4;
 									class Attributes
 									{
-										name="NATO_ENG_ENGM1";
-										description="Engineer (Mines)@NATO ENG";
+										name="BLU_LOGI_LOGIM1";
+										description="Engineer@BLUFOR LOGI";
 										isPlayable=1;
 									};
-									id=251;
-									type="B_soldier_mine_F";
+									id=1614;
+									type="B_engineer_F";
 									class CustomAttributes
 									{
 										class Attribute0
@@ -20274,7 +20697,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -20369,7 +20792,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""engm"",""blu_f"",true]";
+													value="[""logi"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -20388,7 +20811,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="engm";
+													value="logi";
 												};
 											};
 										};
@@ -20403,15 +20826,15 @@ class Mission
 										position[]={46,5.0014391,26.049999};
 									};
 									side="West";
-									flags=5;
+									flags=4;
 									class Attributes
 									{
-										name="NATO_ENG_ENGM2";
-										description="Engineer (Mines)@NATO ENG";
+										name="BLU_LOGI_LOGIM2";
+										description="Engineer@BLUFOR LOGI";
 										isPlayable=1;
 									};
-									id=252;
-									type="B_soldier_mine_F";
+									id=1615;
+									type="B_engineer_F";
 									class CustomAttributes
 									{
 										class Attribute0
@@ -20448,7 +20871,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -20562,7 +20985,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""engm"",""blu_f"",true]";
+													value="[""logi"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -20581,7 +21004,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="engm";
+													value="logi";
 												};
 											};
 										};
@@ -20591,7 +21014,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="NATO_ENG_GRP";
+								name="BLU_LOGI_GRP";
 							};
 							id=248;
 							class CustomAttributes
@@ -20611,7 +21034,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -20630,14 +21053,14 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[""x\tmf\addons\orbat\textures\gray_engineer.paa"",""ENG"",""x\tmf\addons\orbat\textures\modif_o.paa"",20]";
+											value="[""x\tmf\addons\orbat\textures\gray_engineer.paa"",""ENG"",""x\tmf\addons\orbat\textures\modif_o.paa"",11]";
 										};
 									};
 								};
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -20649,7 +21072,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="NATO ENG";
+											value="BLUFOR LOGI";
 										};
 									};
 								};
@@ -20713,8 +21136,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="NATO_M1_VC";
-										description="Commander@NATO Mike 1";
+										name="BLU_M1_VC";
+										description="Commander@BLUFOR Mike 1";
 										isPlayable=1;
 									};
 									id=387;
@@ -20755,7 +21178,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -20850,7 +21273,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""vc"",""blu_f"",true]";
+													value="[""vc"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -20887,8 +21310,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_M1_VG";
-										description="Gunner@NATO Mike 1";
+										name="BLU_M1_VG";
+										description="Gunner@BLUFOR Mike 1";
 										isPlayable=1;
 									};
 									id=389;
@@ -20910,7 +21333,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""vg"",""blu_f"",true]";
+													value="[""vg"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -21005,7 +21428,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -21023,8 +21446,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_M1_VD";
-										description="Driver@NATO Mike 1";
+										name="BLU_M1_VD";
+										description="Driver@BLUFOR Mike 1";
 										isPlayable=1;
 									};
 									id=391;
@@ -21065,7 +21488,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -21091,7 +21514,7 @@ class Mission
 										class Attribute3
 										{
 											property="ace_isEngineer";
-											expression="if !(_value == ([0,1] select (_this getUnitTrait 'engineer'))|| {_value == -1}) then {_this setVariable ['ace_isEngineer', _value, true]}";
+											expression="if !(_value == ([0, 1] select (_this getUnitTrait 'engineer')) || {_value == -1}) then {_this setVariable ['ace_isEngineer', _value, true]}";
 											class Value
 											{
 												class data
@@ -21141,7 +21564,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""vd"",""blu_f"",true]";
+													value="[""vd"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -21170,7 +21593,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="NATO_M1_GRP";
+								name="BLU_M1_GRP";
 							};
 							id=386;
 							class CustomAttributes
@@ -21190,7 +21613,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -21216,7 +21639,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -21228,7 +21651,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="NATO M1";
+											value="BLUFOR M1";
 										};
 									};
 								};
@@ -21292,8 +21715,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="NATO_M2_VC";
-										description="Commander@NATO Mike 2";
+										name="BLU_M2_VC";
+										description="Commander@BLUFOR Mike 2";
 										isPlayable=1;
 									};
 									id=429;
@@ -21334,7 +21757,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -21429,7 +21852,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""vc"",""blu_f"",true]";
+													value="[""vc"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -21466,8 +21889,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_M2_VG";
-										description="Gunner@NATO Mike 2";
+										name="BLU_M2_VG";
+										description="Gunner@BLUFOR Mike 2";
 										isPlayable=1;
 									};
 									id=430;
@@ -21489,7 +21912,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""vg"",""blu_f"",true]";
+													value="[""vg"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -21584,7 +22007,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -21602,8 +22025,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_M2_VD";
-										description="Driver@NATO Mike 2";
+										name="BLU_M2_VD";
+										description="Driver@BLUFOR Mike 2";
 										isPlayable=1;
 									};
 									id=431;
@@ -21644,7 +22067,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -21670,7 +22093,7 @@ class Mission
 										class Attribute3
 										{
 											property="ace_isEngineer";
-											expression="if !(_value == ([0,1] select (_this getUnitTrait 'engineer'))|| {_value == -1}) then {_this setVariable ['ace_isEngineer', _value, true]}";
+											expression="if !(_value == ([0, 1] select (_this getUnitTrait 'engineer')) || {_value == -1}) then {_this setVariable ['ace_isEngineer', _value, true]}";
 											class Value
 											{
 												class data
@@ -21720,7 +22143,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""vd"",""blu_f"",true]";
+													value="[""vd"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -21749,7 +22172,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="NATO_M2_GRP";
+								name="BLU_M2_GRP";
 							};
 							id=428;
 							class CustomAttributes
@@ -21769,7 +22192,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -21795,7 +22218,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -21807,7 +22230,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="NATO M2";
+											value="BLUFOR M2";
 										};
 									};
 								};
@@ -21871,8 +22294,8 @@ class Mission
 									class Attributes
 									{
 										rank="SERGEANT";
-										name="NATO_G1_VC";
-										description="Commander@NATO Gambler 1";
+										name="BLU_G1_VC";
+										description="Commander@BLUFOR Gambler 1";
 										isPlayable=1;
 									};
 									id=457;
@@ -21913,7 +22336,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -22008,7 +22431,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""vc"",""blu_f"",true]";
+													value="[""vc"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -22046,8 +22469,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="NATO_G1_VG";
-										description="Gunner@NATO Gambler 1";
+										name="BLU_G1_VG";
+										description="Gunner@BLUFOR Gambler 1";
 										isPlayable=1;
 									};
 									id=458;
@@ -22069,7 +22492,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""vg"",""blu_f"",true]";
+													value="[""vg"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -22164,7 +22587,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -22182,8 +22605,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_G1_VD";
-										description="Driver@NATO Gambler 1";
+										name="BLU_G1_VD";
+										description="Driver@BLUFOR Gambler 1";
 										isPlayable=1;
 									};
 									id=459;
@@ -22224,7 +22647,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -22250,7 +22673,7 @@ class Mission
 										class Attribute3
 										{
 											property="ace_isEngineer";
-											expression="if !(_value == ([0,1] select (_this getUnitTrait 'engineer'))|| {_value == -1}) then {_this setVariable ['ace_isEngineer', _value, true]}";
+											expression="if !(_value == ([0, 1] select (_this getUnitTrait 'engineer')) || {_value == -1}) then {_this setVariable ['ace_isEngineer', _value, true]}";
 											class Value
 											{
 												class data
@@ -22300,7 +22723,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""vd"",""blu_f"",true]";
+													value="[""vd"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -22329,7 +22752,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="NATO_G1_GRP";
+								name="BLU_G1_GRP";
 							};
 							id=456;
 							class CustomAttributes
@@ -22349,7 +22772,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -22375,7 +22798,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -22387,7 +22810,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="NATO G1";
+											value="BLUFOR G1";
 										};
 									};
 								};
@@ -22451,8 +22874,8 @@ class Mission
 									class Attributes
 									{
 										rank="SERGEANT";
-										name="NATO_G2_VC";
-										description="Commander@NATO Gambler 2";
+										name="BLU_G2_VC";
+										description="Commander@BLUFOR Gambler 2";
 										isPlayable=1;
 									};
 									id=461;
@@ -22493,7 +22916,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -22588,7 +23011,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""vc"",""blu_f"",true]";
+													value="[""vc"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -22626,8 +23049,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="NATO_G2_VG";
-										description="Gunner@NATO Gambler 2";
+										name="BLU_G2_VG";
+										description="Gunner@BLUFOR Gambler 2";
 										isPlayable=1;
 									};
 									id=462;
@@ -22649,7 +23072,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""vg"",""blu_f"",true]";
+													value="[""vg"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -22744,7 +23167,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -22762,8 +23185,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_G2_VD";
-										description="Driver@NATO Gambler 2";
+										name="BLU_G2_VD";
+										description="Driver@BLUFOR Gambler 2";
 										isPlayable=1;
 									};
 									id=463;
@@ -22804,7 +23227,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -22830,7 +23253,7 @@ class Mission
 										class Attribute3
 										{
 											property="ace_isEngineer";
-											expression="if !(_value == ([0,1] select (_this getUnitTrait 'engineer'))|| {_value == -1}) then {_this setVariable ['ace_isEngineer', _value, true]}";
+											expression="if !(_value == ([0, 1] select (_this getUnitTrait 'engineer')) || {_value == -1}) then {_this setVariable ['ace_isEngineer', _value, true]}";
 											class Value
 											{
 												class data
@@ -22880,7 +23303,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""vd"",""blu_f"",true]";
+													value="[""vd"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -22909,7 +23332,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="NATO_G2_GRP";
+								name="BLU_G2_GRP";
 							};
 							id=460;
 							class CustomAttributes
@@ -22929,7 +23352,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -22955,7 +23378,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -22967,7 +23390,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="NATO G2";
+											value="BLUFOR G2";
 										};
 									};
 								};
@@ -23031,8 +23454,8 @@ class Mission
 									class Attributes
 									{
 										rank="LIEUTENANT";
-										name="NATO_PHT1_HP";
-										description="Pilot@NATO Phantom 1";
+										name="BLU_PHT1_HP";
+										description="Pilot@BLUFOR Phantom 1";
 										isPlayable=1;
 									};
 									id=489;
@@ -23073,7 +23496,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -23168,7 +23591,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hp"",""blu_f"",true]";
+													value="[""hp"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -23206,8 +23629,8 @@ class Mission
 									class Attributes
 									{
 										rank="SERGEANT";
-										name="NATO_PHT1_HCC";
-										description="Copilot@NATO Phantom 1";
+										name="BLU_PHT1_HCC";
+										description="Copilot@BLUFOR Phantom 1";
 										isPlayable=1;
 									};
 									id=491;
@@ -23248,7 +23671,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -23343,7 +23766,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hcc"",""blu_f"",true]";
+													value="[""hcc"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -23380,8 +23803,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_PHT1_HC1";
-										description="Door Gunner@NATO Phantom 1";
+										name="BLU_PHT1_HC1";
+										description="Door Gunner@BLUFOR Phantom 1";
 										isPlayable=1;
 									};
 									id=492;
@@ -23422,7 +23845,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -23517,7 +23940,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hc"",""blu_f"",true]";
+													value="[""hc"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -23554,8 +23977,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_PHT1_HC2";
-										description="Door Gunner@NATO Phantom 1";
+										name="BLU_PHT1_HC2";
+										description="Door Gunner@BLUFOR Phantom 1";
 										isPlayable=1;
 									};
 									id=493;
@@ -23596,7 +24019,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -23691,7 +24114,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hc"",""blu_f"",true]";
+													value="[""hc"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -23720,7 +24143,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="NATO_PHT1_GRP";
+								name="BLU_PHT1_GRP";
 							};
 							id=488;
 							class CustomAttributes
@@ -23740,7 +24163,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[1,6]";
+											value="[1]";
 										};
 									};
 								};
@@ -23766,7 +24189,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -23778,7 +24201,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="NATO PHT1";
+											value="BLUFOR PHT1";
 										};
 									};
 								};
@@ -23842,8 +24265,8 @@ class Mission
 									class Attributes
 									{
 										rank="LIEUTENANT";
-										name="NATO_PHT2_HP";
-										description="Pilot@NATO Phantom 2";
+										name="BLU_PHT2_HP";
+										description="Pilot@BLUFOR Phantom 2";
 										isPlayable=1;
 									};
 									id=495;
@@ -23884,7 +24307,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -23979,7 +24402,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hp"",""blu_f"",true]";
+													value="[""hp"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -24017,8 +24440,8 @@ class Mission
 									class Attributes
 									{
 										rank="SERGEANT";
-										name="NATO_PHT2_HCC";
-										description="Copilot@NATO Phantom 2";
+										name="BLU_PHT2_HCC";
+										description="Copilot@BLUFOR Phantom 2";
 										isPlayable=1;
 									};
 									id=496;
@@ -24059,7 +24482,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -24154,7 +24577,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hcc"",""blu_f"",true]";
+													value="[""hcc"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -24191,8 +24614,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_PHT2_HC1";
-										description="Door Gunner@NATO Phantom 2";
+										name="BLU_PHT2_HC1";
+										description="Door Gunner@BLUFOR Phantom 2";
 										isPlayable=1;
 									};
 									id=497;
@@ -24233,7 +24656,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -24347,7 +24770,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hc"",""blu_f"",true]";
+													value="[""hc"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -24384,8 +24807,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_PHT2_HC2";
-										description="Door Gunner@NATO Phantom 2";
+										name="BLU_PHT2_HC2";
+										description="Door Gunner@BLUFOR Phantom 2";
 										isPlayable=1;
 									};
 									id=498;
@@ -24426,7 +24849,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -24521,7 +24944,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hc"",""blu_f"",true]";
+													value="[""hc"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -24550,7 +24973,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="NATO_PHT2_GRP";
+								name="BLU_PHT2_GRP";
 							};
 							id=494;
 							class CustomAttributes
@@ -24570,7 +24993,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[1,6]";
+											value="[1]";
 										};
 									};
 								};
@@ -24596,7 +25019,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -24608,7 +25031,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="NATO PHT2";
+											value="BLUFOR PHT2";
 										};
 									};
 								};
@@ -24672,8 +25095,8 @@ class Mission
 									class Attributes
 									{
 										rank="LIEUTENANT";
-										name="NATO_RVN1_HP";
-										description="Pilot@NATO Raven 1";
+										name="BLU_RVN1_HP";
+										description="Pilot@BLUFOR Raven 1";
 										isPlayable=1;
 									};
 									id=530;
@@ -24714,7 +25137,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -24809,7 +25232,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hp"",""blu_f"",true]";
+													value="[""hp"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -24847,8 +25270,8 @@ class Mission
 									class Attributes
 									{
 										rank="SERGEANT";
-										name="NATO_RVN1_HCC";
-										description="Copilot@NATO Raven 1";
+										name="BLU_RVN1_HCC";
+										description="Copilot@BLUFOR Raven 1";
 										isPlayable=1;
 									};
 									id=531;
@@ -24889,7 +25312,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -24984,7 +25407,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hcc"",""blu_f"",true]";
+													value="[""hcc"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -25013,7 +25436,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="NATO_RVN1_GRP";
+								name="BLU_RVN1_GRP";
 							};
 							id=529;
 							class CustomAttributes
@@ -25033,7 +25456,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[1,6]";
+											value="[1]";
 										};
 									};
 								};
@@ -25059,7 +25482,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -25071,7 +25494,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="NATO RVN1";
+											value="BLUFOR RVN1";
 										};
 									};
 								};
@@ -25135,8 +25558,8 @@ class Mission
 									class Attributes
 									{
 										rank="LIEUTENANT";
-										name="NATO_RVN2_HP";
-										description="Pilot@NATO Raven 2";
+										name="BLU_RVN2_HP";
+										description="Pilot@BLUFOR Raven 2";
 										isPlayable=1;
 									};
 									id=533;
@@ -25177,7 +25600,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -25272,7 +25695,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hp"",""blu_f"",true]";
+													value="[""hp"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -25310,8 +25733,8 @@ class Mission
 									class Attributes
 									{
 										rank="SERGEANT";
-										name="NATO_RVN2_HCC";
-										description="Copilot@NATO Raven 2";
+										name="BLU_RVN2_HCC";
+										description="Copilot@BLUFOR Raven 2";
 										isPlayable=1;
 									};
 									id=534;
@@ -25352,7 +25775,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -25447,7 +25870,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hcc"",""blu_f"",true]";
+													value="[""hcc"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -25476,7 +25899,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="NATO_RVN2_GRP";
+								name="BLU_RVN2_GRP";
 							};
 							id=532;
 							class CustomAttributes
@@ -25496,7 +25919,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[1,6]";
+											value="[1]";
 										};
 									};
 								};
@@ -25522,7 +25945,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -25534,7 +25957,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="NATO RVN2";
+											value="BLUFOR RVN2";
 										};
 									};
 								};
@@ -25597,8 +26020,8 @@ class Mission
 									flags=7;
 									class Attributes
 									{
-										name="NATO_FLC_JP1";
-										description="Pilot@NATO Falcon";
+										name="BLU_TLN_JP1";
+										description="Pilot@BLUFOR Talon";
 										isPlayable=1;
 									};
 									id=1538;
@@ -25639,7 +26062,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -25734,7 +26157,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""jp"",""blu_f"",true]";
+													value="[""jp"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -25771,8 +26194,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_FLC_JP2";
-										description="Pilot@NATO Falcon";
+										name="BLU_TLN_JP2";
+										description="Pilot@BLUFOR Talon";
 										isPlayable=1;
 									};
 									id=1539;
@@ -25813,7 +26236,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -25908,7 +26331,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""jp"",""blu_f"",true]";
+													value="[""jp"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -25937,7 +26360,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="NATO_FLC_GRP";
+								name="BLU_FLC_GRP";
 							};
 							id=1537;
 							class CustomAttributes
@@ -25957,7 +26380,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[1,6]";
+											value="[1]";
 										};
 									};
 								};
@@ -25976,14 +26399,14 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[""x\tmf\addons\orbat\textures\purple_fixedwing.paa"",""FLC"","""",6]";
+											value="[""x\tmf\addons\orbat\textures\purple_fixedwing.paa"",""TLN"","""",6]";
 										};
 									};
 								};
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -25995,7 +26418,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="NATO FLC";
+											value="BLUFOR TLN";
 										};
 									};
 								};
@@ -26058,8 +26481,8 @@ class Mission
 									flags=7;
 									class Attributes
 									{
-										name="NATO_JIP_R1";
-										description="Spare Rifleman@NATO JIP";
+										name="BLU_JIP_R1";
+										description="Spare Rifleman@BLUFOR JIP";
 										isPlayable=1;
 									};
 									id=1544;
@@ -26100,7 +26523,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -26195,7 +26618,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""blu_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -26213,8 +26636,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_JIP_R2";
-										description="Spare Rifleman@NATO JIP";
+										name="BLU_JIP_R2";
+										description="Spare Rifleman@BLUFOR JIP";
 										isPlayable=1;
 									};
 									id=1545;
@@ -26255,7 +26678,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -26350,7 +26773,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""blu_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -26368,8 +26791,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_JIP_R3";
-										description="Spare Rifleman@NATO JIP";
+										name="BLU_JIP_R3";
+										description="Spare Rifleman@BLUFOR JIP";
 										isPlayable=1;
 									};
 									id=1546;
@@ -26410,7 +26833,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -26505,7 +26928,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""blu_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -26523,8 +26946,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_JIP_R4";
-										description="Spare Rifleman@NATO JIP";
+										name="BLU_JIP_R4";
+										description="Spare Rifleman@BLUFOR JIP";
 										isPlayable=1;
 									};
 									id=1547;
@@ -26565,7 +26988,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -26660,7 +27083,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""blu_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -26678,8 +27101,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_JIP_R5";
-										description="Spare Rifleman@NATO JIP";
+										name="BLU_JIP_R5";
+										description="Spare Rifleman@BLUFOR JIP";
 										isPlayable=1;
 									};
 									id=1548;
@@ -26720,7 +27143,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -26815,7 +27238,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""blu_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -26833,8 +27256,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_JIP_R6";
-										description="Spare Rifleman@NATO JIP";
+										name="BLU_JIP_R6";
+										description="Spare Rifleman@BLUFOR JIP";
 										isPlayable=1;
 									};
 									id=1549;
@@ -26875,7 +27298,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -26970,7 +27393,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""blu_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -26988,8 +27411,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_JIP_R7";
-										description="Spare Rifleman@NATO JIP";
+										name="BLU_JIP_R7";
+										description="Spare Rifleman@BLUFOR JIP";
 										isPlayable=1;
 									};
 									id=1550;
@@ -27030,7 +27453,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -27125,7 +27548,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""blu_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -27143,8 +27566,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="NATO_JIP_R8";
-										description="Spare Rifleman@NATO JIP";
+										name="BLU_JIP_R8";
+										description="Spare Rifleman@BLUFOR JIP";
 										isPlayable=1;
 									};
 									id=1551;
@@ -27185,7 +27608,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="blu_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -27280,7 +27703,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""blu_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -27290,7 +27713,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="NATO_JIP_GRP";
+								name="BLU_JIP_GRP";
 							};
 							id=1543;
 							class CustomAttributes
@@ -27336,7 +27759,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -27348,7 +27771,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="NATO JIP";
+											value="BLUFOR JIP";
 										};
 									};
 								};
@@ -27403,8 +27826,8 @@ class Mission
 									class Attributes
 									{
 										rank="LIEUTENANT";
-										name="CSAT_HQ_CO";
-										description="Platoon leader@CSAT HQ";
+										name="OPF_HQ_CO";
+										description="Platoon leader@OPFOR HQ";
 										isPlayable=1;
 									};
 									id=874;
@@ -27445,7 +27868,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -27540,7 +27963,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""co"",""opf_f"",true]";
+													value="[""co"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -27578,8 +28001,8 @@ class Mission
 									class Attributes
 									{
 										rank="SERGEANT";
-										name="CSAT_HQ_SGT";
-										description="Platoon Sergeant@CSAT HQ";
+										name="OPF_HQ_SGT";
+										description="Platoon Sergeant@OPFOR HQ";
 										isPlayable=1;
 									};
 									id=875;
@@ -27620,7 +28043,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -27715,7 +28138,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""sl"",""opf_f"",true]";
+													value="[""sl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -27753,8 +28176,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="CSAT_HQ_FAC";
-										description="Forward Air Controller@CSAT HQ";
+										name="OPF_HQ_FAC";
+										description="Forward Air Controller@OPFOR HQ";
 										isPlayable=1;
 									};
 									id=876;
@@ -27795,7 +28218,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -27890,7 +28313,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""fac"",""opf_f"",true]";
+													value="[""fac"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -27928,8 +28351,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="CSAT_HQ_UAV";
-										description="UAV Operator@CSAT HQ";
+										name="OPF_HQ_UAV";
+										description="UAV Operator@OPFOR HQ";
 										isPlayable=1;
 									};
 									id=1603;
@@ -27957,6 +28380,25 @@ class Mission
 										};
 										class Attribute1
 										{
+											property="TMF_assignGear_faction";
+											expression="false";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"STRING"
+														};
+													};
+													value="example_loadout";
+												};
+											};
+										};
+										class Attribute2
+										{
 											property="TMF_assignGear_enabled";
 											expression="false";
 											class Value
@@ -27974,7 +28416,7 @@ class Mission
 												};
 											};
 										};
-										class Attribute2
+										class Attribute3
 										{
 											property="TMF_Channellist";
 											expression="_this setVariable ['TMF_Channellist',_value,true];";
@@ -27993,7 +28435,7 @@ class Mission
 												};
 											};
 										};
-										class Attribute3
+										class Attribute4
 										{
 											property="pitch";
 											expression="_this setpitch _value;";
@@ -28012,7 +28454,7 @@ class Mission
 												};
 											};
 										};
-										class Attribute4
+										class Attribute5
 										{
 											property="speaker";
 											expression="_this setspeaker _value;";
@@ -28031,7 +28473,7 @@ class Mission
 												};
 											};
 										};
-										class Attribute5
+										class Attribute6
 										{
 											property="TMF_assignGear_full";
 											expression="[_this,  _value] call TMF_assignGear_fnc_helper";
@@ -28046,11 +28488,11 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""UAV"",""opf_f"",true]";
+													value="[""UAV"",""example_loadout"",true]";
 												};
 											};
 										};
-										class Attribute6
+										class Attribute7
 										{
 											property="TMF_assignGear_role";
 											expression="false";
@@ -28069,7 +28511,7 @@ class Mission
 												};
 											};
 										};
-										nAttributes=7;
+										nAttributes=8;
 									};
 								};
 								class Item4
@@ -28083,8 +28525,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_HQ_D";
-										description="Driver@CSAT HQ";
+										name="OPF_HQ_D";
+										description="Driver@OPFOR HQ";
 										isPlayable=1;
 									};
 									id=1604;
@@ -28092,25 +28534,6 @@ class Mission
 									class CustomAttributes
 									{
 										class Attribute0
-										{
-											property="TMF_assignGear_full";
-											expression="[_this,  _value] call TMF_assignGear_fnc_helper";
-											class Value
-											{
-												class data
-												{
-													class type
-													{
-														type[]=
-														{
-															"STRING"
-														};
-													};
-													value="[""r"",""opf_f"",true]";
-												};
-											};
-										};
-										class Attribute1
 										{
 											property="TMF_SpecialistMarker";
 											expression="_this setVariable ['TMF_SpecialistMarker',_value,true];";
@@ -28129,64 +28552,26 @@ class Mission
 												};
 											};
 										};
+										class Attribute1
+										{
+											property="TMF_assignGear_faction";
+											expression="false";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"STRING"
+														};
+													};
+													value="example_loadout";
+												};
+											};
+										};
 										class Attribute2
-										{
-											property="speaker";
-											expression="_this setspeaker _value;";
-											class Value
-											{
-												class data
-												{
-													class type
-													{
-														type[]=
-														{
-															"STRING"
-														};
-													};
-													value="Male02PER";
-												};
-											};
-										};
-										class Attribute3
-										{
-											property="pitch";
-											expression="_this setpitch _value;";
-											class Value
-											{
-												class data
-												{
-													class type
-													{
-														type[]=
-														{
-															"SCALAR"
-														};
-													};
-													value=1;
-												};
-											};
-										};
-										class Attribute4
-										{
-											property="TMF_Channellist";
-											expression="_this setVariable ['TMF_Channellist',_value,true];";
-											class Value
-											{
-												class data
-												{
-													class type
-													{
-														type[]=
-														{
-															"STRING"
-														};
-													};
-													value="[]";
-												};
-											};
-										};
-										class Attribute5
 										{
 											property="TMF_assignGear_enabled";
 											expression="false";
@@ -28205,13 +28590,89 @@ class Mission
 												};
 											};
 										};
-										nAttributes=6;
+										class Attribute3
+										{
+											property="TMF_Channellist";
+											expression="_this setVariable ['TMF_Channellist',_value,true];";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"STRING"
+														};
+													};
+													value="[]";
+												};
+											};
+										};
+										class Attribute4
+										{
+											property="pitch";
+											expression="_this setpitch _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"SCALAR"
+														};
+													};
+													value=1;
+												};
+											};
+										};
+										class Attribute5
+										{
+											property="speaker";
+											expression="_this setspeaker _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"STRING"
+														};
+													};
+													value="Male02PER";
+												};
+											};
+										};
+										class Attribute6
+										{
+											property="TMF_assignGear_full";
+											expression="[_this,  _value] call TMF_assignGear_fnc_helper";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"STRING"
+														};
+													};
+													value="[""r"",""example_loadout"",true]";
+												};
+											};
+										};
+										nAttributes=7;
 									};
 								};
 							};
 							class Attributes
 							{
-								name="CSAT_CO_GRP";
+								name="OPF_CO_GRP";
 							};
 							id=873;
 							class CustomAttributes
@@ -28257,7 +28718,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -28269,7 +28730,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="CSAT CO";
+											value="OPFOR CO";
 										};
 									};
 								};
@@ -28333,8 +28794,8 @@ class Mission
 									class Attributes
 									{
 										rank="SERGEANT";
-										name="CSAT_ASL_SL";
-										description="Squad Leader@CSAT ASL";
+										name="OPF_ASL_SL";
+										description="Squad Leader@OPFOR ASL";
 										isPlayable=1;
 									};
 									id=878;
@@ -28375,7 +28836,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -28470,7 +28931,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""sl"",""opf_f"",true]";
+													value="[""sl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -28508,8 +28969,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="CSAT_ASL_M";
-										description="Medic@CSAT ASL";
+										name="OPF_ASL_M";
+										description="Medic@OPFOR ASL";
 										isPlayable=1;
 									};
 									id=879;
@@ -28550,7 +29011,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -28645,7 +29106,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""m"",""opf_f"",true]";
+													value="[""m"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -28674,7 +29135,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="CSAT_ASL_GRP";
+								name="OPF_ASL_GRP";
 							};
 							id=877;
 							class CustomAttributes
@@ -28720,7 +29181,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -28732,7 +29193,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="CSAT ASL";
+											value="OPFOR ASL";
 										};
 									};
 								};
@@ -28796,8 +29257,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="CSAT_A1_FTL";
-										description="Fireteam Leader@CSAT A1";
+										name="OPF_A1_FTL";
+										description="Fireteam Leader@OPFOR A1";
 										isPlayable=1;
 									};
 									id=881;
@@ -28838,7 +29299,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -28933,7 +29394,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ftl"",""opf_f"",true]";
+													value="[""ftl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -28970,8 +29431,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_A1_AR";
-										description="Autorifleman@CSAT A1";
+										name="OPF_A1_AR";
+										description="Autorifleman@OPFOR A1";
 										isPlayable=1;
 									};
 									id=882;
@@ -29012,7 +29473,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -29088,7 +29549,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ar"",""opf_f"",true]";
+													value="[""ar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -29125,8 +29586,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_A1_AAR";
-										description="Asst. Autorifleman@CSAT A1";
+										name="OPF_A1_AAR";
+										description="Asst. Autorifleman@OPFOR A1";
 										isPlayable=1;
 									};
 									id=883;
@@ -29167,7 +29628,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -29243,7 +29704,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""aar"",""opf_f"",true]";
+													value="[""aar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -29280,8 +29741,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_A1_RAT";
-										description="Rifleman (AT)@CSAT A1";
+										name="OPF_A1_RAT";
+										description="Rifleman (AT)@OPFOR A1";
 										isPlayable=1;
 									};
 									id=884;
@@ -29322,7 +29783,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -29398,7 +29859,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""rat"",""opf_f"",true]";
+													value="[""rat"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -29435,8 +29896,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_A1_R";
-										description="Rifleman@CSAT A1";
+										name="OPF_A1_R";
+										description="Rifleman@OPFOR A1";
 										isPlayable=1;
 									};
 									id=885;
@@ -29458,7 +29919,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""opf_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -29534,7 +29995,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -29571,8 +30032,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_A1_CLS";
-										description="Rifleman (CLS)@CSAT A1";
+										name="OPF_A1_CLS";
+										description="Rifleman (CLS)@OPFOR A1";
 										isPlayable=1;
 									};
 									id=886;
@@ -29613,7 +30074,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -29689,7 +30150,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""cls"",""opf_f"",true]";
+													value="[""cls"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -29718,7 +30179,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="CSAT_A1_GRP";
+								name="OPF_A1_GRP";
 							};
 							id=880;
 							class CustomAttributes
@@ -29764,7 +30225,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -29776,7 +30237,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="CSAT A1";
+											value="OPFOR A1";
 										};
 									};
 								};
@@ -29840,8 +30301,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="CSAT_A2_FTL";
-										description="Fireteam Leader@CSAT A2";
+										name="OPF_A2_FTL";
+										description="Fireteam Leader@OPFOR A2";
 										isPlayable=1;
 									};
 									id=888;
@@ -29882,7 +30343,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -29977,7 +30438,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ftl"",""opf_f"",true]";
+													value="[""ftl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -30014,8 +30475,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_A2_AR";
-										description="Autorifleman@CSAT A2";
+										name="OPF_A2_AR";
+										description="Autorifleman@OPFOR A2";
 										isPlayable=1;
 									};
 									id=889;
@@ -30056,7 +30517,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -30132,7 +30593,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ar"",""opf_f"",true]";
+													value="[""ar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -30169,8 +30630,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_A2_AAR";
-										description="Asst. Autorifleman@CSAT A2";
+										name="OPF_A2_AAR";
+										description="Asst. Autorifleman@OPFOR A2";
 										isPlayable=1;
 									};
 									id=890;
@@ -30211,7 +30672,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -30287,7 +30748,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""aar"",""opf_f"",true]";
+													value="[""aar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -30324,8 +30785,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_A2_RAT";
-										description="Rifleman (AT)@CSAT A2";
+										name="OPF_A2_RAT";
+										description="Rifleman (AT)@OPFOR A2";
 										isPlayable=1;
 									};
 									id=891;
@@ -30366,7 +30827,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -30442,7 +30903,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""rat"",""opf_f"",true]";
+													value="[""rat"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -30479,8 +30940,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_A2_R";
-										description="Rifleman@CSAT A2";
+										name="OPF_A2_R";
+										description="Rifleman@OPFOR A2";
 										isPlayable=1;
 									};
 									id=892;
@@ -30502,7 +30963,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""opf_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -30578,7 +31039,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -30615,8 +31076,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_A2_CLS";
-										description="Rifleman (CLS)@CSAT A2";
+										name="OPF_A2_CLS";
+										description="Rifleman (CLS)@OPFOR A2";
 										isPlayable=1;
 									};
 									id=893;
@@ -30657,7 +31118,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -30733,7 +31194,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""cls"",""opf_f"",true]";
+													value="[""cls"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -30762,7 +31223,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="CSAT_A2_GRP";
+								name="OPF_A2_GRP";
 							};
 							id=887;
 							class CustomAttributes
@@ -30808,7 +31269,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -30820,7 +31281,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="CSAT A2";
+											value="OPFOR A2";
 										};
 									};
 								};
@@ -30884,8 +31345,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="CSAT_A3_FTL";
-										description="Fireteam Leader@CSAT A3";
+										name="OPF_A3_FTL";
+										description="Fireteam Leader@OPFOR A3";
 										isPlayable=1;
 									};
 									id=895;
@@ -30926,7 +31387,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -31021,7 +31482,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ftl"",""opf_f"",true]";
+													value="[""ftl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -31058,8 +31519,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_A3_AR";
-										description="Autorifleman@CSAT A3";
+										name="OPF_A3_AR";
+										description="Autorifleman@OPFOR A3";
 										isPlayable=1;
 									};
 									id=896;
@@ -31100,7 +31561,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -31176,7 +31637,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ar"",""opf_f"",true]";
+													value="[""ar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -31213,8 +31674,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_A3_AAR";
-										description="Asst. Autorifleman@CSAT A3";
+										name="OPF_A3_AAR";
+										description="Asst. Autorifleman@OPFOR A3";
 										isPlayable=1;
 									};
 									id=897;
@@ -31255,7 +31716,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -31331,7 +31792,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""aar"",""opf_f"",true]";
+													value="[""aar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -31368,8 +31829,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_A3_RAT";
-										description="Rifleman (AT)@CSAT A3";
+										name="OPF_A3_RAT";
+										description="Rifleman (AT)@OPFOR A3";
 										isPlayable=1;
 									};
 									id=898;
@@ -31410,7 +31871,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -31486,7 +31947,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""rat"",""opf_f"",true]";
+													value="[""rat"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -31523,8 +31984,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_A3_R";
-										description="Rifleman@CSAT A3";
+										name="OPF_A3_R";
+										description="Rifleman@OPFOR A3";
 										isPlayable=1;
 									};
 									id=899;
@@ -31546,7 +32007,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""opf_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -31622,7 +32083,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -31659,8 +32120,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_A3_CLS";
-										description="Rifleman (CLS)@CSAT A3";
+										name="OPF_A3_CLS";
+										description="Rifleman (CLS)@OPFOR A3";
 										isPlayable=1;
 									};
 									id=900;
@@ -31701,7 +32162,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -31777,7 +32238,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""cls"",""opf_f"",true]";
+													value="[""cls"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -31806,7 +32267,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="CSAT_A3_GRP";
+								name="OPF_A3_GRP";
 							};
 							id=894;
 							class CustomAttributes
@@ -31852,7 +32313,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -31864,7 +32325,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="CSAT A3";
+											value="OPFOR A3";
 										};
 									};
 								};
@@ -31928,8 +32389,8 @@ class Mission
 									class Attributes
 									{
 										rank="SERGEANT";
-										name="CSAT_BSL_SL";
-										description="Squad Leader@CSAT BSL";
+										name="OPF_BSL_SL";
+										description="Squad Leader@OPFOR BSL";
 										isPlayable=1;
 									};
 									id=902;
@@ -31970,7 +32431,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -32065,7 +32526,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""sl"",""opf_f"",true]";
+													value="[""sl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -32103,8 +32564,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="CSAT_BSL_M";
-										description="Medic@CSAT BSL";
+										name="OPF_BSL_M";
+										description="Medic@OPFOR BSL";
 										isPlayable=1;
 									};
 									id=903;
@@ -32145,7 +32606,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -32240,7 +32701,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""m"",""opf_f"",true]";
+													value="[""m"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -32269,7 +32730,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="CSAT_BSL_GRP";
+								name="OPF_BSL_GRP";
 							};
 							id=901;
 							class CustomAttributes
@@ -32315,7 +32776,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -32327,7 +32788,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="CSAT BSL";
+											value="OPFOR BSL";
 										};
 									};
 								};
@@ -32391,8 +32852,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="CSAT_B1_FTL";
-										description="Fireteam Leader@CSAT B1";
+										name="OPF_B1_FTL";
+										description="Fireteam Leader@OPFOR B1";
 										isPlayable=1;
 									};
 									id=905;
@@ -32433,7 +32894,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -32528,7 +32989,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ftl"",""opf_f"",true]";
+													value="[""ftl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -32565,8 +33026,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_B1_AR";
-										description="Autorifleman@CSAT B1";
+										name="OPF_B1_AR";
+										description="Autorifleman@OPFOR B1";
 										isPlayable=1;
 									};
 									id=906;
@@ -32607,7 +33068,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -32683,7 +33144,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ar"",""opf_f"",true]";
+													value="[""ar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -32720,8 +33181,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_B1_AAR";
-										description="Asst. Autorifleman@CSAT B1";
+										name="OPF_B1_AAR";
+										description="Asst. Autorifleman@OPFOR B1";
 										isPlayable=1;
 									};
 									id=907;
@@ -32762,7 +33223,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -32838,7 +33299,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""aar"",""opf_f"",true]";
+													value="[""aar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -32875,8 +33336,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_B1_RAT";
-										description="Rifleman (AT)@CSAT B1";
+										name="OPF_B1_RAT";
+										description="Rifleman (AT)@OPFOR B1";
 										isPlayable=1;
 									};
 									id=908;
@@ -32917,7 +33378,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -32993,7 +33454,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""rat"",""opf_f"",true]";
+													value="[""rat"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -33030,8 +33491,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_B1_R";
-										description="Rifleman@CSAT B1";
+										name="OPF_B1_R";
+										description="Rifleman@OPFOR B1";
 										isPlayable=1;
 									};
 									id=909;
@@ -33053,7 +33514,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""opf_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -33129,7 +33590,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -33166,8 +33627,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_B1_CLS";
-										description="Rifleman (CLS)@CSAT B1";
+										name="OPF_B1_CLS";
+										description="Rifleman (CLS)@OPFOR B1";
 										isPlayable=1;
 									};
 									id=910;
@@ -33208,7 +33669,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -33284,7 +33745,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""cls"",""opf_f"",true]";
+													value="[""cls"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -33313,7 +33774,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="CSAT_B1_GRP";
+								name="OPF_B1_GRP";
 							};
 							id=904;
 							class CustomAttributes
@@ -33359,7 +33820,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -33371,7 +33832,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="CSAT B1";
+											value="OPFOR B1";
 										};
 									};
 								};
@@ -33435,8 +33896,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="CSAT_B2_FTL";
-										description="Fireteam Leader@CSAT B2";
+										name="OPF_B2_FTL";
+										description="Fireteam Leader@OPFOR B2";
 										isPlayable=1;
 									};
 									id=912;
@@ -33477,7 +33938,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -33572,7 +34033,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ftl"",""opf_f"",true]";
+													value="[""ftl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -33609,8 +34070,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_B2_AR";
-										description="Autorifleman@CSAT B2";
+										name="OPF_B2_AR";
+										description="Autorifleman@OPFOR B2";
 										isPlayable=1;
 									};
 									id=913;
@@ -33651,7 +34112,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -33727,7 +34188,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ar"",""opf_f"",true]";
+													value="[""ar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -33764,8 +34225,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_B2_AAR";
-										description="Asst. Autorifleman@CSAT B2";
+										name="OPF_B2_AAR";
+										description="Asst. Autorifleman@OPFOR B2";
 										isPlayable=1;
 									};
 									id=914;
@@ -33806,7 +34267,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -33882,7 +34343,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""aar"",""opf_f"",true]";
+													value="[""aar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -33919,8 +34380,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_B2_RAT";
-										description="Rifleman (AT)@CSAT B2";
+										name="OPF_B2_RAT";
+										description="Rifleman (AT)@OPFOR B2";
 										isPlayable=1;
 									};
 									id=915;
@@ -33961,7 +34422,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -34037,7 +34498,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""rat"",""opf_f"",true]";
+													value="[""rat"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -34074,8 +34535,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_B2_R";
-										description="Rifleman@CSAT B2";
+										name="OPF_B2_R";
+										description="Rifleman@OPFOR B2";
 										isPlayable=1;
 									};
 									id=916;
@@ -34097,7 +34558,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""opf_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -34173,7 +34634,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -34210,8 +34671,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_B2_CLS";
-										description="Rifleman (CLS)@CSAT B2";
+										name="OPF_B2_CLS";
+										description="Rifleman (CLS)@OPFOR B2";
 										isPlayable=1;
 									};
 									id=917;
@@ -34252,7 +34713,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -34328,7 +34789,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""cls"",""opf_f"",true]";
+													value="[""cls"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -34357,7 +34818,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="CSAT_B2_GRP";
+								name="OPF_B2_GRP";
 							};
 							id=911;
 							class CustomAttributes
@@ -34403,7 +34864,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -34415,7 +34876,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="CSAT B2";
+											value="OPFOR B2";
 										};
 									};
 								};
@@ -34479,8 +34940,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="CSAT_B3_FTL";
-										description="Fireteam Leader@CSAT B3";
+										name="OPF_B3_FTL";
+										description="Fireteam Leader@OPFOR B3";
 										isPlayable=1;
 									};
 									id=919;
@@ -34521,7 +34982,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -34616,7 +35077,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ftl"",""opf_f"",true]";
+													value="[""ftl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -34653,8 +35114,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_B3_AR";
-										description="Autorifleman@CSAT B3";
+										name="OPF_B3_AR";
+										description="Autorifleman@OPFOR B3";
 										isPlayable=1;
 									};
 									id=920;
@@ -34695,7 +35156,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -34771,7 +35232,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ar"",""opf_f"",true]";
+													value="[""ar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -34808,8 +35269,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_B3_AAR";
-										description="Asst. Autorifleman@CSAT B3";
+										name="OPF_B3_AAR";
+										description="Asst. Autorifleman@OPFOR B3";
 										isPlayable=1;
 									};
 									id=921;
@@ -34850,7 +35311,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -34926,7 +35387,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""aar"",""opf_f"",true]";
+													value="[""aar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -34963,8 +35424,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_B3_RAT";
-										description="Rifleman (AT)@CSAT B3";
+										name="OPF_B3_RAT";
+										description="Rifleman (AT)@OPFOR B3";
 										isPlayable=1;
 									};
 									id=922;
@@ -35005,7 +35466,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -35081,7 +35542,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""rat"",""opf_f"",true]";
+													value="[""rat"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -35118,8 +35579,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_B3_R";
-										description="Rifleman@CSAT B3";
+										name="OPF_B3_R";
+										description="Rifleman@OPFOR B3";
 										isPlayable=1;
 									};
 									id=923;
@@ -35141,7 +35602,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""opf_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -35217,7 +35678,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -35254,8 +35715,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_B3_CLS";
-										description="Rifleman (CLS)@CSAT B3";
+										name="OPF_B3_CLS";
+										description="Rifleman (CLS)@OPFOR B3";
 										isPlayable=1;
 									};
 									id=924;
@@ -35296,7 +35757,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -35372,7 +35833,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""cls"",""opf_f"",true]";
+													value="[""cls"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -35401,7 +35862,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="CSAT_B3_GRP";
+								name="OPF_B3_GRP";
 							};
 							id=918;
 							class CustomAttributes
@@ -35447,7 +35908,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -35459,7 +35920,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="CSAT B3";
+											value="OPFOR B3";
 										};
 									};
 								};
@@ -35523,8 +35984,8 @@ class Mission
 									class Attributes
 									{
 										rank="SERGEANT";
-										name="CSAT_CSL_SL";
-										description="Squad Leader@CSAT CSL";
+										name="OPF_CSL_SL";
+										description="Squad Leader@OPFOR CSL";
 										isPlayable=1;
 									};
 									id=926;
@@ -35565,7 +36026,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -35660,7 +36121,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""sl"",""opf_f"",true]";
+													value="[""sl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -35698,8 +36159,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="CSAT_CSL_M";
-										description="Medic@CSAT CSL";
+										name="OPF_CSL_M";
+										description="Medic@OPFOR CSL";
 										isPlayable=1;
 									};
 									id=927;
@@ -35740,7 +36201,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -35835,7 +36296,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""m"",""opf_f"",true]";
+													value="[""m"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -35864,7 +36325,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="CSAT_CSL_GRP";
+								name="OPF_CSL_GRP";
 							};
 							id=925;
 							class CustomAttributes
@@ -35910,7 +36371,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -35922,7 +36383,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="CSAT CSL";
+											value="OPFOR CSL";
 										};
 									};
 								};
@@ -35986,8 +36447,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="CSAT_C1_FTL";
-										description="Fireteam Leader@CSAT C1";
+										name="OPF_C1_FTL";
+										description="Fireteam Leader@OPFOR C1";
 										isPlayable=1;
 									};
 									id=929;
@@ -36028,7 +36489,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -36123,7 +36584,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ftl"",""opf_f"",true]";
+													value="[""ftl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -36160,8 +36621,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_C1_AR";
-										description="Autorifleman@CSAT C1";
+										name="OPF_C1_AR";
+										description="Autorifleman@OPFOR C1";
 										isPlayable=1;
 									};
 									id=930;
@@ -36202,7 +36663,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -36278,7 +36739,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ar"",""opf_f"",true]";
+													value="[""ar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -36315,8 +36776,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_C1_AAR";
-										description="Asst. Autorifleman@CSAT C1";
+										name="OPF_C1_AAR";
+										description="Asst. Autorifleman@OPFOR C1";
 										isPlayable=1;
 									};
 									id=931;
@@ -36357,7 +36818,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -36433,7 +36894,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""aar"",""opf_f"",true]";
+													value="[""aar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -36470,8 +36931,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_C1_RAT";
-										description="Rifleman (AT)@CSAT C1";
+										name="OPF_C1_RAT";
+										description="Rifleman (AT)@OPFOR C1";
 										isPlayable=1;
 									};
 									id=932;
@@ -36512,7 +36973,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -36588,7 +37049,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""rat"",""opf_f"",true]";
+													value="[""rat"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -36625,8 +37086,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_C1_R";
-										description="Rifleman@CSAT C1";
+										name="OPF_C1_R";
+										description="Rifleman@OPFOR C1";
 										isPlayable=1;
 									};
 									id=933;
@@ -36648,7 +37109,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""opf_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -36724,7 +37185,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -36761,8 +37222,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_C1_CLS";
-										description="Rifleman (CLS)@CSAT C1";
+										name="OPF_C1_CLS";
+										description="Rifleman (CLS)@OPFOR C1";
 										isPlayable=1;
 									};
 									id=934;
@@ -36803,7 +37264,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -36879,7 +37340,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""cls"",""opf_f"",true]";
+													value="[""cls"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -36908,7 +37369,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="CSAT_C1_GRP";
+								name="OPF_C1_GRP";
 							};
 							id=928;
 							class CustomAttributes
@@ -36954,7 +37415,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -36966,7 +37427,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="CSAT C1";
+											value="OPFOR C1";
 										};
 									};
 								};
@@ -37030,8 +37491,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="CSAT_C2_FTL";
-										description="Fireteam Leader@CSAT C2";
+										name="OPF_C2_FTL";
+										description="Fireteam Leader@OPFOR C2";
 										isPlayable=1;
 									};
 									id=936;
@@ -37072,7 +37533,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -37167,7 +37628,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ftl"",""opf_f"",true]";
+													value="[""ftl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -37204,8 +37665,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_C2_AR";
-										description="Autorifleman@CSAT C2";
+										name="OPF_C2_AR";
+										description="Autorifleman@OPFOR C2";
 										isPlayable=1;
 									};
 									id=937;
@@ -37246,7 +37707,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -37322,7 +37783,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ar"",""opf_f"",true]";
+													value="[""ar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -37359,8 +37820,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_C2_AAR";
-										description="Asst. Autorifleman@CSAT C2";
+										name="OPF_C2_AAR";
+										description="Asst. Autorifleman@OPFOR C2";
 										isPlayable=1;
 									};
 									id=938;
@@ -37401,7 +37862,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -37477,7 +37938,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""aar"",""opf_f"",true]";
+													value="[""aar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -37514,8 +37975,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_C2_RAT";
-										description="Rifleman (AT)@CSAT C2";
+										name="OPF_C2_RAT";
+										description="Rifleman (AT)@OPFOR C2";
 										isPlayable=1;
 									};
 									id=939;
@@ -37556,7 +38017,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -37632,7 +38093,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""rat"",""opf_f"",true]";
+													value="[""rat"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -37669,8 +38130,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_C2_R";
-										description="Rifleman@CSAT C2";
+										name="OPF_C2_R";
+										description="Rifleman@OPFOR C2";
 										isPlayable=1;
 									};
 									id=940;
@@ -37692,7 +38153,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""opf_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -37768,7 +38229,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -37805,8 +38266,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_C2_CLS";
-										description="Rifleman (CLS)@CSAT C2";
+										name="OPF_C2_CLS";
+										description="Rifleman (CLS)@OPFOR C2";
 										isPlayable=1;
 									};
 									id=941;
@@ -37847,7 +38308,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -37923,7 +38384,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""cls"",""opf_f"",true]";
+													value="[""cls"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -37952,7 +38413,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="CSAT_C2_GRP";
+								name="OPF_C2_GRP";
 							};
 							id=935;
 							class CustomAttributes
@@ -37998,7 +38459,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -38010,7 +38471,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="CSAT C2";
+											value="OPFOR C2";
 										};
 									};
 								};
@@ -38074,8 +38535,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="CSAT_C3_FTL";
-										description="Fireteam Leader@CSAT C3";
+										name="OPF_C3_FTL";
+										description="Fireteam Leader@OPFOR C3";
 										isPlayable=1;
 									};
 									id=943;
@@ -38116,7 +38577,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -38211,7 +38672,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ftl"",""opf_f"",true]";
+													value="[""ftl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -38248,8 +38709,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_C3_AR";
-										description="Autorifleman@CSAT C3";
+										name="OPF_C3_AR";
+										description="Autorifleman@OPFOR C3";
 										isPlayable=1;
 									};
 									id=944;
@@ -38290,7 +38751,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -38366,7 +38827,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ar"",""opf_f"",true]";
+													value="[""ar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -38403,8 +38864,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_C3_AAR";
-										description="Asst. Autorifleman@CSAT C3";
+										name="OPF_C3_AAR";
+										description="Asst. Autorifleman@OPFOR C3";
 										isPlayable=1;
 									};
 									id=945;
@@ -38445,7 +38906,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -38521,7 +38982,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""aar"",""opf_f"",true]";
+													value="[""aar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -38558,8 +39019,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_C3_RAT";
-										description="Rifleman (AT)@CSAT C3";
+										name="OPF_C3_RAT";
+										description="Rifleman (AT)@OPFOR C3";
 										isPlayable=1;
 									};
 									id=946;
@@ -38600,7 +39061,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -38676,7 +39137,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""rat"",""opf_f"",true]";
+													value="[""rat"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -38713,8 +39174,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_C3_R";
-										description="Rifleman@CSAT C3";
+										name="OPF_C3_R";
+										description="Rifleman@OPFOR C3";
 										isPlayable=1;
 									};
 									id=947;
@@ -38736,7 +39197,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""opf_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -38812,7 +39273,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -38849,8 +39310,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_C3_CLS";
-										description="Rifleman (CLS)@CSAT C3";
+										name="OPF_C3_CLS";
+										description="Rifleman (CLS)@OPFOR C3";
 										isPlayable=1;
 									};
 									id=948;
@@ -38891,7 +39352,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -38967,7 +39428,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""cls"",""opf_f"",true]";
+													value="[""cls"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -38996,7 +39457,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="CSAT_C3_GRP";
+								name="OPF_C3_GRP";
 							};
 							id=942;
 							class CustomAttributes
@@ -39042,7 +39503,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -39054,7 +39515,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="CSAT C3";
+											value="OPFOR C3";
 										};
 									};
 								};
@@ -39118,8 +39579,8 @@ class Mission
 									class Attributes
 									{
 										rank="SERGEANT";
-										name="CSAT_WSL_SL";
-										description="Squad Leader@CSAT WSL";
+										name="OPF_WSL_SL";
+										description="Squad Leader@OPFOR WSL";
 										isPlayable=1;
 									};
 									id=950;
@@ -39160,7 +39621,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -39255,7 +39716,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""sl"",""opf_f"",true]";
+													value="[""sl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -39293,8 +39754,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="CSAT_WSL_M";
-										description="Medic@CSAT WSL";
+										name="OPF_WSL_M";
+										description="Medic@OPFOR WSL";
 										isPlayable=1;
 									};
 									id=951;
@@ -39335,7 +39796,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -39430,7 +39891,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""m"",""opf_f"",true]";
+													value="[""m"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -39459,7 +39920,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="CSAT_WSL_GRP";
+								name="OPF_WSL_GRP";
 							};
 							id=949;
 							class CustomAttributes
@@ -39479,7 +39940,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -39505,7 +39966,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -39517,7 +39978,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="CSAT WSL";
+											value="OPFOR WSL";
 										};
 									};
 								};
@@ -39581,8 +40042,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="CSAT_MMG1_MMGTL";
-										description="Team Leader@CSAT MMG1";
+										name="OPF_MMG1_MMGTL";
+										description="Team Leader@OPFOR MMG1";
 										isPlayable=1;
 									};
 									id=953;
@@ -39623,7 +40084,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -39737,7 +40198,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""mmgtl"",""opf_f"",true]";
+													value="[""mmgtl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -39774,8 +40235,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_MMG1_MMGG";
-										description="Gunner@CSAT MMG1";
+										name="OPF_MMG1_MMGG";
+										description="Gunner@OPFOR MMG1";
 										isPlayable=1;
 									};
 									id=954;
@@ -39816,7 +40277,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -39930,7 +40391,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""mmgg"",""opf_f"",true]";
+													value="[""mmgg"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -39967,8 +40428,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_MMG1_MMGAC";
-										description="Ammocarrier@CSAT MMG1";
+										name="OPF_MMG1_MMGAC";
+										description="Ammocarrier@OPFOR MMG1";
 										isPlayable=1;
 									};
 									id=955;
@@ -40009,7 +40470,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -40123,7 +40584,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""mmgac"",""opf_f"",true]";
+													value="[""mmgac"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -40152,7 +40613,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="CSAT_MMG1_GRP";
+								name="OPF_MMG1_GRP";
 							};
 							id=952;
 							class CustomAttributes
@@ -40172,7 +40633,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -40198,7 +40659,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -40210,7 +40671,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="CSAT MMG1";
+											value="OPFOR MMG1";
 										};
 									};
 								};
@@ -40274,8 +40735,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="CSAT_MMG2_MMGTL";
-										description="Team Leader@CSAT MMG2";
+										name="OPF_MMG2_MMGTL";
+										description="Team Leader@OPFOR MMG2";
 										isPlayable=1;
 									};
 									id=1436;
@@ -40316,7 +40777,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -40430,7 +40891,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""mmgtl"",""opf_f"",true]";
+													value="[""mmgtl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -40467,8 +40928,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_MMG2_MMGG";
-										description="Gunner@CSAT MMG2";
+										name="OPF_MMG2_MMGG";
+										description="Gunner@OPFOR MMG2";
 										isPlayable=1;
 									};
 									id=1437;
@@ -40509,7 +40970,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -40623,7 +41084,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""mmgg"",""opf_f"",true]";
+													value="[""mmgg"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -40660,8 +41121,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_MMG2_MMGAC";
-										description="Ammocarrier@CSAT MMG2";
+										name="OPF_MMG2_MMGAC";
+										description="Ammocarrier@OPFOR MMG2";
 										isPlayable=1;
 									};
 									id=1438;
@@ -40702,7 +41163,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -40816,7 +41277,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""mmgac"",""opf_f"",true]";
+													value="[""mmgac"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -40845,7 +41306,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="CSAT_MMG2_GRP";
+								name="OPF_MMG2_GRP";
 							};
 							id=1435;
 							class CustomAttributes
@@ -40865,7 +41326,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -40891,7 +41352,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -40903,7 +41364,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="CSAT MMG2";
+											value="OPFOR MMG2";
 										};
 									};
 								};
@@ -40967,8 +41428,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="CSAT_HMG1_HMGTL";
-										description="Team Leader@CSAT HMG1";
+										name="OPF_HMG1_HMGTL";
+										description="Team Leader@OPFOR HMG1";
 										isPlayable=1;
 									};
 									id=1440;
@@ -41009,7 +41470,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -41123,7 +41584,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hmgtl"",""opf_f"",true]";
+													value="[""hmgtl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -41160,8 +41621,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_HMG1_HMGG";
-										description="Gunner@CSAT HMG1";
+										name="OPF_HMG1_HMGG";
+										description="Gunner@OPFOR HMG1";
 										isPlayable=1;
 									};
 									id=1441;
@@ -41202,7 +41663,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -41316,7 +41777,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hmgg"",""opf_f"",true]";
+													value="[""hmgg"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -41353,8 +41814,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_HMG1_HMGAC";
-										description="Ammocarrier@CSAT HMG1";
+										name="OPF_HMG1_HMGAC";
+										description="Ammocarrier@OPFOR HMG1";
 										isPlayable=1;
 									};
 									id=1442;
@@ -41395,7 +41856,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -41509,7 +41970,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hmgac"",""opf_f"",true]";
+													value="[""hmgac"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -41538,7 +41999,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="CSAT_HMG1_GRP";
+								name="OPF_HMG1_GRP";
 							};
 							id=1439;
 							class CustomAttributes
@@ -41558,7 +42019,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -41584,7 +42045,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -41596,7 +42057,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="CSAT HMG1";
+											value="OPFOR HMG1";
 										};
 									};
 								};
@@ -41660,8 +42121,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="CSAT_HMG2_HMGTL";
-										description="Team Leader@CSAT HMG2";
+										name="OPF_HMG2_HMGTL";
+										description="Team Leader@OPFOR HMG2";
 										isPlayable=1;
 									};
 									id=1452;
@@ -41702,7 +42163,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -41816,7 +42277,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hmgtl"",""opf_f"",true]";
+													value="[""hmgtl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -41853,8 +42314,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_HMG2_HMGG";
-										description="Gunner@CSAT HMG2";
+										name="OPF_HMG2_HMGG";
+										description="Gunner@OPFOR HMG2";
 										isPlayable=1;
 									};
 									id=1453;
@@ -41895,7 +42356,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -42009,7 +42470,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hmgg"",""opf_f"",true]";
+													value="[""hmgg"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -42046,8 +42507,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_HMG2_HMGAC";
-										description="Ammocarrier@CSAT HMG2";
+										name="OPF_HMG2_HMGAC";
+										description="Ammocarrier@OPFOR HMG2";
 										isPlayable=1;
 									};
 									id=1454;
@@ -42088,7 +42549,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -42202,7 +42663,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hmgac"",""opf_f"",true]";
+													value="[""hmgac"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -42231,7 +42692,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="CSAT_HMG2_GRP";
+								name="OPF_HMG2_GRP";
 							};
 							id=1451;
 							class CustomAttributes
@@ -42251,7 +42712,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -42277,7 +42738,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -42289,7 +42750,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="CSAT HMG2";
+											value="OPFOR HMG2";
 										};
 									};
 								};
@@ -42353,8 +42814,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="CSAT_MAT1_MATTL";
-										description="Team Leader@CSAT MAT1";
+										name="OPF_MAT1_MATTL";
+										description="Team Leader@OPFOR MAT1";
 										isPlayable=1;
 									};
 									id=969;
@@ -42395,7 +42856,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -42509,7 +42970,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""mattl"",""opf_f"",true]";
+													value="[""mattl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -42546,8 +43007,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_MAT1_MATG";
-										description="Gunner@CSAT MAT1";
+										name="OPF_MAT1_MATG";
+										description="Gunner@OPFOR MAT1";
 										isPlayable=1;
 									};
 									id=970;
@@ -42588,7 +43049,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -42702,7 +43163,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""matg"",""opf_f"",true]";
+													value="[""matg"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -42739,8 +43200,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_MAT1_MATAC";
-										description="Ammocarrier@CSAT MAT1";
+										name="OPF_MAT1_MATAC";
+										description="Ammocarrier@OPFOR MAT1";
 										isPlayable=1;
 									};
 									id=971;
@@ -42781,7 +43242,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -42895,7 +43356,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""matac"",""opf_f"",true]";
+													value="[""matac"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -42924,7 +43385,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="CSAT_MAT1_GRP";
+								name="OPF_MAT1_GRP";
 							};
 							id=968;
 							class CustomAttributes
@@ -42944,7 +43405,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -42970,7 +43431,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -42982,7 +43443,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="CSAT MAT1";
+											value="OPFOR MAT1";
 										};
 									};
 								};
@@ -43046,8 +43507,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="CSAT_MAT2_MATTL";
-										description="Team Leader@CSAT MAT2";
+										name="OPF_MAT2_MATTL";
+										description="Team Leader@OPFOR MAT2";
 										isPlayable=1;
 									};
 									id=1432;
@@ -43088,7 +43549,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -43202,7 +43663,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""mattl"",""opf_f"",true]";
+													value="[""mattl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -43239,8 +43700,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_MAT2_MATG";
-										description="Gunner@CSAT MAT2";
+										name="OPF_MAT2_MATG";
+										description="Gunner@OPFOR MAT2";
 										isPlayable=1;
 									};
 									id=1433;
@@ -43281,7 +43742,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -43395,7 +43856,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""matg"",""opf_f"",true]";
+													value="[""matg"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -43432,8 +43893,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_MAT2_MATAC";
-										description="Ammocarrier@CSAT MAT2";
+										name="OPF_MAT2_MATAC";
+										description="Ammocarrier@OPFOR MAT2";
 										isPlayable=1;
 									};
 									id=1434;
@@ -43474,7 +43935,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -43588,7 +44049,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""matac"",""opf_f"",true]";
+													value="[""matac"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -43617,7 +44078,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="CSAT_MAT2_GRP";
+								name="OPF_MAT2_GRP";
 							};
 							id=1431;
 							class CustomAttributes
@@ -43637,7 +44098,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -43663,7 +44124,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -43675,7 +44136,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="CSAT MAT2";
+											value="OPFOR MAT2";
 										};
 									};
 								};
@@ -43739,8 +44200,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="CSAT_HAT1_HATTL";
-										description="Team Leader@CSAT HAT1";
+										name="OPF_HAT1_HATTL";
+										description="Team Leader@OPFOR HAT1";
 										isPlayable=1;
 									};
 									id=1444;
@@ -43781,7 +44242,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -43895,7 +44356,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hattl"",""opf_f"",true]";
+													value="[""hattl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -43932,8 +44393,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_HAT1_HATG";
-										description="Gunner@CSAT HAT1";
+										name="OPF_HAT1_HATG";
+										description="Gunner@OPFOR HAT1";
 										isPlayable=1;
 									};
 									id=1445;
@@ -43974,7 +44435,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -44088,7 +44549,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hatg"",""opf_f"",true]";
+													value="[""hatg"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -44125,8 +44586,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_HAT1_HATAC";
-										description="Ammocarrier@CSAT HAT1";
+										name="OPF_HAT1_HATAC";
+										description="Ammocarrier@OPFOR HAT1";
 										isPlayable=1;
 									};
 									id=1446;
@@ -44167,7 +44628,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -44281,7 +44742,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hatac"",""opf_f"",true]";
+													value="[""hatac"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -44310,7 +44771,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="CSAT_HAT1_GRP";
+								name="OPF_HAT1_GRP";
 							};
 							id=1443;
 							class CustomAttributes
@@ -44330,7 +44791,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -44356,7 +44817,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -44368,7 +44829,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="CSAT HAT1";
+											value="OPFOR HAT1";
 										};
 									};
 								};
@@ -44432,8 +44893,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="CSAT_HAT2_HATTL";
-										description="Team Leader@CSAT HAT2";
+										name="OPF_HAT2_HATTL";
+										description="Team Leader@OPFOR HAT2";
 										isPlayable=1;
 									};
 									id=1448;
@@ -44474,7 +44935,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -44588,7 +45049,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hattl"",""opf_f"",true]";
+													value="[""hattl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -44625,8 +45086,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_HAT2_HATG";
-										description="Gunner@CSAT HAT2";
+										name="OPF_HAT2_HATG";
+										description="Gunner@OPFOR HAT2";
 										isPlayable=1;
 									};
 									id=1449;
@@ -44667,7 +45128,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -44781,7 +45242,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hatg"",""opf_f"",true]";
+													value="[""hatg"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -44818,8 +45279,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_HAT2_HATAC";
-										description="Ammocarrier@CSAT HAT2";
+										name="OPF_HAT2_HATAC";
+										description="Ammocarrier@OPFOR HAT2";
 										isPlayable=1;
 									};
 									id=1450;
@@ -44860,7 +45321,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -44974,7 +45435,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hatac"",""opf_f"",true]";
+													value="[""hatac"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -45003,7 +45464,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="CSAT_HAT2_GRP";
+								name="OPF_HAT2_GRP";
 							};
 							id=1447;
 							class CustomAttributes
@@ -45023,7 +45484,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -45049,7 +45510,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -45061,7 +45522,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="CSAT HAT2";
+											value="OPFOR HAT2";
 										};
 									};
 								};
@@ -45125,8 +45586,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="CSAT_MANPADS_SAMAG";
-										description="Team Leader@CSAT MANPADS";
+										name="OPF_MANPADS_SAMAG";
+										description="Team Leader@OPFOR MANPADS";
 										isPlayable=1;
 									};
 									id=985;
@@ -45167,7 +45628,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -45262,7 +45723,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""samag"",""opf_f"",true]";
+													value="[""samag"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -45299,8 +45760,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_MANPADS_SAMG";
-										description="Gunner@CSAT MANPADS";
+										name="OPF_MANPADS_SAMG";
+										description="Gunner@OPFOR MANPADS";
 										isPlayable=1;
 									};
 									id=986;
@@ -45341,7 +45802,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -45455,7 +45916,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""samg"",""opf_f"",true]";
+													value="[""samg"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -45484,7 +45945,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="CSAT_MANPADS_GRP";
+								name="OPF_MANPADS_GRP";
 							};
 							id=984;
 							class CustomAttributes
@@ -45504,7 +45965,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -45530,7 +45991,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -45542,7 +46003,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="CSAT MANPADS";
+											value="OPFOR MANPADS";
 										};
 									};
 								};
@@ -45606,8 +46067,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="CSAT_MTR_MTRTL";
-										description="Team Leader@CSAT MTR";
+										name="OPF_MTR_MTRTL";
+										description="Team Leader@OPFOR MTR";
 										isPlayable=1;
 									};
 									id=988;
@@ -45648,7 +46109,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -45762,7 +46223,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""mtrtl"",""opf_f"",true]";
+													value="[""mtrtl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -45799,8 +46260,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_MTR_MTRG";
-										description="Gunner@CSAT MTR";
+										name="OPF_MTR_MTRG";
+										description="Gunner@OPFOR MTR";
 										isPlayable=1;
 									};
 									id=989;
@@ -45841,7 +46302,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -45955,7 +46416,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""mtrg"",""opf_f"",true]";
+													value="[""mtrg"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -45992,8 +46453,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_MTR_MTRAC";
-										description="Ammocarrier@CSAT MTR";
+										name="OPF_MTR_MTRAC";
+										description="Ammocarrier@OPFOR MTR";
 										isPlayable=1;
 									};
 									id=990;
@@ -46034,7 +46495,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -46129,7 +46590,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""mtrac"",""opf_f"",true]";
+													value="[""mtrac"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -46158,7 +46619,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="CSAT_MTR_GRP";
+								name="OPF_MTR_GRP";
 							};
 							id=987;
 							class CustomAttributes
@@ -46178,7 +46639,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -46204,7 +46665,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -46216,7 +46677,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="CSAT MTR";
+											value="OPFOR MTR";
 										};
 									};
 								};
@@ -46280,8 +46741,8 @@ class Mission
 									class Attributes
 									{
 										rank="LIEUTENANT";
-										name="CSAT_SN_SP";
-										description="Spotter@CSAT SN";
+										name="OPF_SN_SP";
+										description="Spotter@OPFOR SN";
 										isPlayable=1;
 									};
 									id=997;
@@ -46322,7 +46783,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -46417,7 +46878,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""sp"",""opf_f"",true]";
+													value="[""sp"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -46455,8 +46916,8 @@ class Mission
 									class Attributes
 									{
 										rank="SERGEANT";
-										name="CSAT_SN_SN";
-										description="Sniper@CSAT SN";
+										name="OPF_SN_SN";
+										description="Sniper@OPFOR SN";
 										isPlayable=1;
 									};
 									id=998;
@@ -46497,7 +46958,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -46611,7 +47072,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""sn"",""opf_f"",true]";
+													value="[""sn"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -46640,7 +47101,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="CSAT_SN_GRP";
+								name="OPF_SN_GRP";
 							};
 							id=996;
 							class CustomAttributes
@@ -46660,7 +47121,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -46686,7 +47147,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -46698,7 +47159,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="CSAT SN";
+											value="OPFOR SN";
 										};
 									};
 								};
@@ -46758,16 +47219,16 @@ class Mission
 										position[]={44,5.0014391,56.049999};
 									};
 									side="East";
-									flags=7;
+									flags=6;
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="CSAT_ENG_ENG1";
-										description="Engineer Leader (Explosives)@CSAT ENG";
+										name="OPF_LOGI_LOGI1";
+										description="Team Leader@OPFOR LOGI";
 										isPlayable=1;
 									};
-									id=992;
-									type="O_soldier_exp_F";
+									id=1620;
+									type="O_engineer_F";
 									class CustomAttributes
 									{
 										class Attribute0
@@ -46804,7 +47265,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -46829,6 +47290,25 @@ class Mission
 										};
 										class Attribute3
 										{
+											property="face";
+											expression="_this setface _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"STRING"
+														};
+													};
+													value="AfricanHead_03";
+												};
+											};
+										};
+										class Attribute4
+										{
 											property="TMF_Channellist";
 											expression="_this setVariable ['TMF_Channellist',_value,true];";
 											class Value
@@ -46846,7 +47326,7 @@ class Mission
 												};
 											};
 										};
-										class Attribute4
+										class Attribute5
 										{
 											property="pitch";
 											expression="_this setpitch _value;";
@@ -46865,7 +47345,7 @@ class Mission
 												};
 											};
 										};
-										class Attribute5
+										class Attribute6
 										{
 											property="speaker";
 											expression="_this setspeaker _value;";
@@ -46884,7 +47364,7 @@ class Mission
 												};
 											};
 										};
-										class Attribute6
+										class Attribute7
 										{
 											property="TMF_assignGear_full";
 											expression="[_this,  _value] call TMF_assignGear_fnc_helper";
@@ -46899,11 +47379,11 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""eng"",""opf_f"",true]";
+													value="[""logi"",""example_loadout"",true]";
 												};
 											};
 										};
-										class Attribute7
+										class Attribute8
 										{
 											property="TMF_assignGear_role";
 											expression="false";
@@ -46918,11 +47398,11 @@ class Mission
 															"STRING"
 														};
 													};
-													value="eng";
+													value="logi";
 												};
 											};
 										};
-										nAttributes=8;
+										nAttributes=9;
 									};
 								};
 								class Item1
@@ -46933,15 +47413,15 @@ class Mission
 										position[]={43,5.0014391,55.049999};
 									};
 									side="East";
-									flags=5;
+									flags=4;
 									class Attributes
 									{
-										name="CSAT_ENG_ENG2";
-										description="Engineer (Explosives)@CSAT ENG";
+										name="OPF_LOGI_LOGI2";
+										description="Engineer@OPFOR LOGI";
 										isPlayable=1;
 									};
-									id=993;
-									type="O_soldier_exp_F";
+									id=1621;
+									type="O_engineer_F";
 									class CustomAttributes
 									{
 										class Attribute0
@@ -46978,7 +47458,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -47092,7 +47572,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""eng"",""opf_f"",true]";
+													value="[""logi"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -47111,7 +47591,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="eng";
+													value="logi";
 												};
 											};
 										};
@@ -47126,15 +47606,15 @@ class Mission
 										position[]={45,5.0014391,55.049999};
 									};
 									side="East";
-									flags=5;
+									flags=4;
 									class Attributes
 									{
-										name="CSAT_ENG_ENGM1";
-										description="Engineer (Mines)@CSAT ENG";
+										name="OPF_LOGI_LOGIM1";
+										description="Engineer@OPFOR LOGI";
 										isPlayable=1;
 									};
-									id=994;
-									type="O_soldier_mine_F";
+									id=1622;
+									type="O_engineer_F";
 									class CustomAttributes
 									{
 										class Attribute0
@@ -47171,7 +47651,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -47266,7 +47746,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""engm"",""opf_f"",true]";
+													value="[""logi"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -47285,7 +47765,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="engm";
+													value="logi";
 												};
 											};
 										};
@@ -47300,15 +47780,15 @@ class Mission
 										position[]={46,5.0014391,54.049999};
 									};
 									side="East";
-									flags=5;
+									flags=4;
 									class Attributes
 									{
-										name="CSAT_ENG_ENGM2";
-										description="Engineer (Mines)@CSAT ENG";
+										name="OPF_LOGI_LOGIM2";
+										description="Engineer@OPFOR LOGI";
 										isPlayable=1;
 									};
-									id=995;
-									type="O_soldier_mine_F";
+									id=1623;
+									type="O_engineer_F";
 									class CustomAttributes
 									{
 										class Attribute0
@@ -47345,7 +47825,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -47459,7 +47939,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""engm"",""opf_f"",true]";
+													value="[""logi"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -47478,7 +47958,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="engm";
+													value="logi";
 												};
 											};
 										};
@@ -47488,7 +47968,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="CSAT_ENG_GRP";
+								name="OPF_LOGI_GRP";
 							};
 							id=991;
 							class CustomAttributes
@@ -47508,7 +47988,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -47527,14 +48007,14 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[""x\tmf\addons\orbat\textures\gray_engineer.paa"",""ENG"",""x\tmf\addons\orbat\textures\modif_o.paa"",22]";
+											value="[""x\tmf\addons\orbat\textures\gray_engineer.paa"",""ENG"",""x\tmf\addons\orbat\textures\modif_o.paa"",7]";
 										};
 									};
 								};
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -47546,7 +48026,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="CSAT ENG";
+											value="OPFOR LOGI";
 										};
 									};
 								};
@@ -47610,8 +48090,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="CSAT_M1_VC";
-										description="Commander@CSAT Mike 1";
+										name="OPF_M1_VC";
+										description="Commander@OPFOR Mike 1";
 										isPlayable=1;
 									};
 									id=1076;
@@ -47652,7 +48132,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -47747,7 +48227,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""vc"",""opf_f"",true]";
+													value="[""vc"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -47784,8 +48264,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_M1_VG";
-										description="Gunner@CSAT Mike 1";
+										name="OPF_M1_VG";
+										description="Gunner@OPFOR Mike 1";
 										isPlayable=1;
 									};
 									id=1077;
@@ -47807,7 +48287,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""vg"",""opf_f"",true]";
+													value="[""vg"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -47902,7 +48382,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -47920,8 +48400,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_M1_VD";
-										description="Driver@CSAT Mike 1";
+										name="OPF_M1_VD";
+										description="Driver@OPFOR Mike 1";
 										isPlayable=1;
 									};
 									id=1078;
@@ -47962,7 +48442,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -47988,7 +48468,7 @@ class Mission
 										class Attribute3
 										{
 											property="ace_isEngineer";
-											expression="if !(_value == ([0,1] select (_this getUnitTrait 'engineer'))|| {_value == -1}) then {_this setVariable ['ace_isEngineer', _value, true]}";
+											expression="if !(_value == ([0, 1] select (_this getUnitTrait 'engineer')) || {_value == -1}) then {_this setVariable ['ace_isEngineer', _value, true]}";
 											class Value
 											{
 												class data
@@ -48038,7 +48518,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""vd"",""opf_f"",true]";
+													value="[""vd"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -48067,7 +48547,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="CSAT_M1_GRP";
+								name="OPF_M1_GRP";
 							};
 							id=1075;
 							class CustomAttributes
@@ -48087,7 +48567,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -48113,7 +48593,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -48125,7 +48605,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="CSAT M1";
+											value="OPFOR M1";
 										};
 									};
 								};
@@ -48189,8 +48669,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="CSAT_M2_VC";
-										description="Commander@CSAT Mike 2";
+										name="OPF_M2_VC";
+										description="Commander@OPFOR Mike 2";
 										isPlayable=1;
 									};
 									id=1080;
@@ -48231,7 +48711,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -48326,7 +48806,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""vc"",""opf_f"",true]";
+													value="[""vc"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -48363,8 +48843,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_M2_VG";
-										description="Gunner@CSAT Mike 2";
+										name="OPF_M2_VG";
+										description="Gunner@OPFOR Mike 2";
 										isPlayable=1;
 									};
 									id=1081;
@@ -48386,7 +48866,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""vg"",""opf_f"",true]";
+													value="[""vg"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -48481,7 +48961,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -48499,8 +48979,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_M2_VD";
-										description="Driver@CSAT Mike 2";
+										name="OPF_M2_VD";
+										description="Driver@OPFOR Mike 2";
 										isPlayable=1;
 									};
 									id=1082;
@@ -48541,7 +49021,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -48567,7 +49047,7 @@ class Mission
 										class Attribute3
 										{
 											property="ace_isEngineer";
-											expression="if !(_value == ([0,1] select (_this getUnitTrait 'engineer'))|| {_value == -1}) then {_this setVariable ['ace_isEngineer', _value, true]}";
+											expression="if !(_value == ([0, 1] select (_this getUnitTrait 'engineer')) || {_value == -1}) then {_this setVariable ['ace_isEngineer', _value, true]}";
 											class Value
 											{
 												class data
@@ -48617,7 +49097,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""vd"",""opf_f"",true]";
+													value="[""vd"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -48646,7 +49126,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="CSAT_M2_GRP";
+								name="OPF_M2_GRP";
 							};
 							id=1079;
 							class CustomAttributes
@@ -48666,7 +49146,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -48692,7 +49172,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -48704,7 +49184,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="CSAT M2";
+											value="OPFOR M2";
 										};
 									};
 								};
@@ -48768,8 +49248,8 @@ class Mission
 									class Attributes
 									{
 										rank="SERGEANT";
-										name="CSAT_G1_VC";
-										description="Commander@CSAT Gambler 1";
+										name="OPF_G1_VC";
+										description="Commander@OPFOR Gambler 1";
 										isPlayable=1;
 									};
 									id=1092;
@@ -48810,7 +49290,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -48905,7 +49385,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""vc"",""opf_f"",true]";
+													value="[""vc"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -48943,8 +49423,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="CSAT_G1_VG";
-										description="Gunner@CSAT Gambler 1";
+										name="OPF_G1_VG";
+										description="Gunner@OPFOR Gambler 1";
 										isPlayable=1;
 									};
 									id=1093;
@@ -48966,7 +49446,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""vg"",""opf_f"",true]";
+													value="[""vg"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -49061,7 +49541,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -49079,8 +49559,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_G1_VD";
-										description="Driver@CSAT Gambler 1";
+										name="OPF_G1_VD";
+										description="Driver@OPFOR Gambler 1";
 										isPlayable=1;
 									};
 									id=1094;
@@ -49121,7 +49601,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -49147,7 +49627,7 @@ class Mission
 										class Attribute3
 										{
 											property="ace_isEngineer";
-											expression="if !(_value == ([0,1] select (_this getUnitTrait 'engineer'))|| {_value == -1}) then {_this setVariable ['ace_isEngineer', _value, true]}";
+											expression="if !(_value == ([0, 1] select (_this getUnitTrait 'engineer')) || {_value == -1}) then {_this setVariable ['ace_isEngineer', _value, true]}";
 											class Value
 											{
 												class data
@@ -49197,7 +49677,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""vd"",""opf_f"",true]";
+													value="[""vd"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -49226,7 +49706,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="CSAT_G1_GRP";
+								name="OPF_G1_GRP";
 							};
 							id=1091;
 							class CustomAttributes
@@ -49246,7 +49726,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -49272,7 +49752,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -49284,7 +49764,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="CSAT G1";
+											value="OPFOR G1";
 										};
 									};
 								};
@@ -49348,8 +49828,8 @@ class Mission
 									class Attributes
 									{
 										rank="SERGEANT";
-										name="CSAT_G2_VC";
-										description="Commander@CSAT Gambler 2";
+										name="OPF_G2_VC";
+										description="Commander@OPFOR Gambler 2";
 										isPlayable=1;
 									};
 									id=1096;
@@ -49390,7 +49870,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -49485,7 +49965,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""vc"",""opf_f"",true]";
+													value="[""vc"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -49523,8 +50003,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="CSAT_G2_VG";
-										description="Gunner@CSAT Gambler 2";
+										name="OPF_G2_VG";
+										description="Gunner@OPFOR Gambler 2";
 										isPlayable=1;
 									};
 									id=1097;
@@ -49546,7 +50026,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""vg"",""opf_f"",true]";
+													value="[""vg"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -49641,7 +50121,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -49659,8 +50139,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_G2_VD";
-										description="Driver@CSAT Gambler 2";
+										name="OPF_G2_VD";
+										description="Driver@OPFOR Gambler 2";
 										isPlayable=1;
 									};
 									id=1098;
@@ -49701,7 +50181,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -49727,7 +50207,7 @@ class Mission
 										class Attribute3
 										{
 											property="ace_isEngineer";
-											expression="if !(_value == ([0,1] select (_this getUnitTrait 'engineer'))|| {_value == -1}) then {_this setVariable ['ace_isEngineer', _value, true]}";
+											expression="if !(_value == ([0, 1] select (_this getUnitTrait 'engineer')) || {_value == -1}) then {_this setVariable ['ace_isEngineer', _value, true]}";
 											class Value
 											{
 												class data
@@ -49777,7 +50257,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""vd"",""opf_f"",true]";
+													value="[""vd"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -49806,7 +50286,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="CSAT_G2_GRP";
+								name="OPF_G2_GRP";
 							};
 							id=1095;
 							class CustomAttributes
@@ -49826,7 +50306,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -49852,7 +50332,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -49864,7 +50344,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="CSAT G2";
+											value="OPFOR G2";
 										};
 									};
 								};
@@ -49928,8 +50408,8 @@ class Mission
 									class Attributes
 									{
 										rank="LIEUTENANT";
-										name="CSAT_PHT1_HP";
-										description="Pilot@CSAT Phantom 1";
+										name="OPF_PHT1_HP";
+										description="Pilot@OPFOR Phantom 1";
 										isPlayable=1;
 									};
 									id=1108;
@@ -49970,7 +50450,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -50065,7 +50545,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hp"",""opf_f"",true]";
+													value="[""hp"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -50103,8 +50583,8 @@ class Mission
 									class Attributes
 									{
 										rank="SERGEANT";
-										name="CSAT_PHT1_HCC";
-										description="Copilot@CSAT Phantom 1";
+										name="OPF_PHT1_HCC";
+										description="Copilot@OPFOR Phantom 1";
 										isPlayable=1;
 									};
 									id=1109;
@@ -50145,7 +50625,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -50240,7 +50720,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hcc"",""opf_f"",true]";
+													value="[""hcc"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -50277,8 +50757,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_PHT1_HC1";
-										description="Door Gunner@CSAT Phantom 1";
+										name="OPF_PHT1_HC1";
+										description="Door Gunner@OPFOR Phantom 1";
 										isPlayable=1;
 									};
 									id=1110;
@@ -50319,7 +50799,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -50414,7 +50894,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hc"",""opf_f"",true]";
+													value="[""hc"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -50451,8 +50931,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_PHT1_HC2";
-										description="Door Gunner@CSAT Phantom 1";
+										name="OPF_PHT1_HC2";
+										description="Door Gunner@OPFOR Phantom 1";
 										isPlayable=1;
 									};
 									id=1111;
@@ -50493,7 +50973,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -50588,7 +51068,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hc"",""opf_f"",true]";
+													value="[""hc"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -50617,7 +51097,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="CSAT_PHT1_GRP";
+								name="OPF_PHT1_GRP";
 							};
 							id=1107;
 							class CustomAttributes
@@ -50663,7 +51143,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -50675,7 +51155,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="CSAT PHT1";
+											value="OPFOR PHT1";
 										};
 									};
 								};
@@ -50739,8 +51219,8 @@ class Mission
 									class Attributes
 									{
 										rank="LIEUTENANT";
-										name="CSAT_PHT2_HP";
-										description="Pilot@CSAT Phantom 2";
+										name="OPF_PHT2_HP";
+										description="Pilot@OPFOR Phantom 2";
 										isPlayable=1;
 									};
 									id=1113;
@@ -50781,7 +51261,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -50876,7 +51356,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hp"",""opf_f"",true]";
+													value="[""hp"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -50914,8 +51394,8 @@ class Mission
 									class Attributes
 									{
 										rank="SERGEANT";
-										name="CSAT_PHT2_HCC";
-										description="Copilot@CSAT Phantom 2";
+										name="OPF_PHT2_HCC";
+										description="Copilot@OPFOR Phantom 2";
 										isPlayable=1;
 									};
 									id=1114;
@@ -50956,7 +51436,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -51051,7 +51531,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hcc"",""opf_f"",true]";
+													value="[""hcc"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -51088,8 +51568,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_PHT2_HC1";
-										description="Door Gunner@CSAT Phantom 2";
+										name="OPF_PHT2_HC1";
+										description="Door Gunner@OPFOR Phantom 2";
 										isPlayable=1;
 									};
 									id=1115;
@@ -51130,7 +51610,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -51225,7 +51705,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hc"",""opf_f"",true]";
+													value="[""hc"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -51262,8 +51742,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_PHT2_HC2";
-										description="Door Gunner@CSAT Phantom 2";
+										name="OPF_PHT2_HC2";
+										description="Door Gunner@OPFOR Phantom 2";
 										isPlayable=1;
 									};
 									id=1116;
@@ -51304,7 +51784,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -51399,7 +51879,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hc"",""opf_f"",true]";
+													value="[""hc"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -51428,7 +51908,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="CSAT_PHT2_GRP";
+								name="OPF_PHT2_GRP";
 							};
 							id=1112;
 							class CustomAttributes
@@ -51474,7 +51954,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -51486,7 +51966,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="CSAT PHT2";
+											value="OPFOR PHT2";
 										};
 									};
 								};
@@ -51550,8 +52030,8 @@ class Mission
 									class Attributes
 									{
 										rank="LIEUTENANT";
-										name="CSAT_RVN1_HP";
-										description="Pilot@CSAT Raven 1";
+										name="OPF_RVN1_HP";
+										description="Pilot@OPFOR Raven 1";
 										isPlayable=1;
 									};
 									id=1128;
@@ -51592,7 +52072,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -51687,7 +52167,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hp"",""opf_f"",true]";
+													value="[""hp"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -51725,8 +52205,8 @@ class Mission
 									class Attributes
 									{
 										rank="SERGEANT";
-										name="CSAT_RVN1_HCC";
-										description="Copilot@CSAT Raven 1";
+										name="OPF_RVN1_HCC";
+										description="Copilot@OPFOR Raven 1";
 										isPlayable=1;
 									};
 									id=1129;
@@ -51767,7 +52247,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -51862,7 +52342,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hcc"",""opf_f"",true]";
+													value="[""hcc"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -51891,7 +52371,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="CSAT_RVN1_GRP";
+								name="OPF_RVN1_GRP";
 								placementRadius=10;
 							};
 							id=1127;
@@ -51938,7 +52418,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -51950,7 +52430,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="CSAT RVN1";
+											value="OPFOR RVN1";
 										};
 									};
 								};
@@ -52014,8 +52494,8 @@ class Mission
 									class Attributes
 									{
 										rank="LIEUTENANT";
-										name="CSAT_RVN2_HP";
-										description="Pilot@CSAT Raven 2";
+										name="OPF_RVN2_HP";
+										description="Pilot@OPFOR Raven 2";
 										isPlayable=1;
 									};
 									id=1131;
@@ -52056,7 +52536,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -52151,7 +52631,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hp"",""opf_f"",true]";
+													value="[""hp"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -52189,8 +52669,8 @@ class Mission
 									class Attributes
 									{
 										rank="SERGEANT";
-										name="CSAT_RVN2_HCC";
-										description="Copilot@CSAT Raven 2";
+										name="OPF_RVN2_HCC";
+										description="Copilot@OPFOR Raven 2";
 										isPlayable=1;
 									};
 									id=1132;
@@ -52231,7 +52711,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -52326,7 +52806,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hcc"",""opf_f"",true]";
+													value="[""hcc"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -52355,7 +52835,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="CSAT_RVN2_GRP";
+								name="OPF_RVN2_GRP";
 							};
 							id=1130;
 							class CustomAttributes
@@ -52401,7 +52881,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -52413,7 +52893,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="CSAT RVN2";
+											value="OPFOR RVN2";
 										};
 									};
 								};
@@ -52476,8 +52956,8 @@ class Mission
 									flags=7;
 									class Attributes
 									{
-										name="CSAT_FLC_JP1";
-										description="Pilot@CSAT Falcon";
+										name="OPF_TLN_JP1";
+										description="Pilot@OPFOR Talon";
 										isPlayable=1;
 									};
 									id=1541;
@@ -52518,7 +52998,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -52613,7 +53093,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""jp"",""opf_f"",true]";
+													value="[""jp"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -52650,8 +53130,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_FLC_JP2";
-										description="Pilot@CSAT Falcon";
+										name="OPF_TLN_JP2";
+										description="Pilot@OPFOR Talon";
 										isPlayable=1;
 									};
 									id=1542;
@@ -52692,7 +53172,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -52787,7 +53267,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""jp"",""opf_f"",true]";
+													value="[""jp"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -52816,7 +53296,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="CSAT_FLC_GRP";
+								name="OPF_FLC_GRP";
 							};
 							id=1540;
 							class CustomAttributes
@@ -52855,14 +53335,14 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[""x\tmf\addons\orbat\textures\purple_fixedwing.paa"",""FLC"","""",6]";
+											value="[""x\tmf\addons\orbat\textures\purple_fixedwing.paa"",""TLN"","""",6]";
 										};
 									};
 								};
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -52874,7 +53354,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="CSAT FLC";
+											value="OPFOR TLN";
 										};
 									};
 								};
@@ -52937,8 +53417,8 @@ class Mission
 									flags=7;
 									class Attributes
 									{
-										name="CSAT_JIP_R1";
-										description="Spare Rifleman@CSAT JIP";
+										name="OPF_JIP_R1";
+										description="Spare Rifleman@OPFOR JIP";
 										isPlayable=1;
 									};
 									id=1562;
@@ -52979,7 +53459,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -53074,7 +53554,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""opf_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -53092,8 +53572,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_JIP_R2";
-										description="Spare Rifleman@CSAT JIP";
+										name="OPF_JIP_R2";
+										description="Spare Rifleman@OPFOR JIP";
 										isPlayable=1;
 									};
 									id=1563;
@@ -53134,7 +53614,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -53229,7 +53709,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""opf_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -53247,8 +53727,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_JIP_R3";
-										description="Spare Rifleman@CSAT JIP";
+										name="OPF_JIP_R3";
+										description="Spare Rifleman@OPFOR JIP";
 										isPlayable=1;
 									};
 									id=1564;
@@ -53289,7 +53769,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -53384,7 +53864,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""opf_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -53402,8 +53882,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_JIP_R4";
-										description="Spare Rifleman@CSAT JIP";
+										name="OPF_JIP_R4";
+										description="Spare Rifleman@OPFOR JIP";
 										isPlayable=1;
 									};
 									id=1565;
@@ -53444,7 +53924,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -53539,7 +54019,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""opf_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -53557,8 +54037,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_JIP_R5";
-										description="Spare Rifleman@CSAT JIP";
+										name="OPF_JIP_R5";
+										description="Spare Rifleman@OPFOR JIP";
 										isPlayable=1;
 									};
 									id=1566;
@@ -53599,7 +54079,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -53694,7 +54174,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""opf_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -53712,8 +54192,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_JIP_R6";
-										description="Spare Rifleman@CSAT JIP";
+										name="OPF_JIP_R6";
+										description="Spare Rifleman@OPFOR JIP";
 										isPlayable=1;
 									};
 									id=1567;
@@ -53754,7 +54234,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -53849,7 +54329,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""opf_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -53867,8 +54347,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_JIP_R7";
-										description="Spare Rifleman@CSAT JIP";
+										name="OPF_JIP_R7";
+										description="Spare Rifleman@OPFOR JIP";
 										isPlayable=1;
 									};
 									id=1568;
@@ -53909,7 +54389,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -54004,7 +54484,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""opf_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -54022,8 +54502,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="CSAT_JIP_R8";
-										description="Spare Rifleman@CSAT JIP";
+										name="OPF_JIP_R8";
+										description="Spare Rifleman@OPFOR JIP";
 										isPlayable=1;
 									};
 									id=1569;
@@ -54064,7 +54544,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="opf_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -54159,7 +54639,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""opf_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -54169,7 +54649,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="CSAT_JIP_GRP";
+								name="OPF_JIP_GRP";
 							};
 							id=1561;
 							class CustomAttributes
@@ -54215,7 +54695,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -54227,7 +54707,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="CSAT JIP";
+											value="OPFOR JIP";
 										};
 									};
 								};
@@ -54282,8 +54762,8 @@ class Mission
 									class Attributes
 									{
 										rank="LIEUTENANT";
-										name="AAF_HQ_CO";
-										description="Platoon leader@AAF HQ";
+										name="IND_HQ_CO";
+										description="Platoon leader@INDFOR HQ";
 										isPlayable=1;
 									};
 									id=1156;
@@ -54324,7 +54804,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -54438,7 +54918,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""co"",""ind_f"",true]";
+													value="[""co"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -54476,8 +54956,8 @@ class Mission
 									class Attributes
 									{
 										rank="SERGEANT";
-										name="AAF_HQ_SGT";
-										description="Platoon Sergeant@AAF HQ";
+										name="IND_HQ_SGT";
+										description="Platoon Sergeant@INDFOR HQ";
 										isPlayable=1;
 									};
 									id=1157;
@@ -54518,7 +54998,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -54613,7 +55093,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""sl"",""ind_f"",true]";
+													value="[""sl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -54651,8 +55131,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="AAF_HQ_FAC";
-										description="Forward Air Controller@AAF HQ";
+										name="IND_HQ_FAC";
+										description="Forward Air Controller@INDFOR HQ";
 										isPlayable=1;
 									};
 									id=1158;
@@ -54693,7 +55173,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -54788,7 +55268,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""fac"",""ind_f"",true]";
+													value="[""fac"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -54826,8 +55306,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="AAF_HQ_UAV";
-										description="UAV Operator@AAF HQ";
+										name="IND_HQ_UAV";
+										description="UAV Operator@INDFOR HQ";
 										isPlayable=1;
 									};
 									id=1601;
@@ -54855,6 +55335,25 @@ class Mission
 										};
 										class Attribute1
 										{
+											property="TMF_assignGear_faction";
+											expression="false";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"STRING"
+														};
+													};
+													value="example_loadout";
+												};
+											};
+										};
+										class Attribute2
+										{
 											property="TMF_assignGear_enabled";
 											expression="false";
 											class Value
@@ -54872,7 +55371,7 @@ class Mission
 												};
 											};
 										};
-										class Attribute2
+										class Attribute3
 										{
 											property="TMF_Channellist";
 											expression="_this setVariable ['TMF_Channellist',_value,true];";
@@ -54891,7 +55390,7 @@ class Mission
 												};
 											};
 										};
-										class Attribute3
+										class Attribute4
 										{
 											property="pitch";
 											expression="_this setpitch _value;";
@@ -54910,7 +55409,7 @@ class Mission
 												};
 											};
 										};
-										class Attribute4
+										class Attribute5
 										{
 											property="speaker";
 											expression="_this setspeaker _value;";
@@ -54929,7 +55428,7 @@ class Mission
 												};
 											};
 										};
-										class Attribute5
+										class Attribute6
 										{
 											property="TMF_assignGear_full";
 											expression="[_this,  _value] call TMF_assignGear_fnc_helper";
@@ -54944,11 +55443,11 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""UAV"",""ind_f"",true]";
+													value="[""UAV"",""example_loadout"",true]";
 												};
 											};
 										};
-										class Attribute6
+										class Attribute7
 										{
 											property="TMF_assignGear_role";
 											expression="false";
@@ -54967,7 +55466,7 @@ class Mission
 												};
 											};
 										};
-										nAttributes=7;
+										nAttributes=8;
 									};
 								};
 								class Item4
@@ -54981,8 +55480,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_HQ_D";
-										description="Driver@AAF HQ";
+										name="IND_HQ_D";
+										description="Driver@INDFOR HQ";
 										isPlayable=1;
 									};
 									id=1602;
@@ -54990,25 +55489,6 @@ class Mission
 									class CustomAttributes
 									{
 										class Attribute0
-										{
-											property="TMF_assignGear_full";
-											expression="[_this,  _value] call TMF_assignGear_fnc_helper";
-											class Value
-											{
-												class data
-												{
-													class type
-													{
-														type[]=
-														{
-															"STRING"
-														};
-													};
-													value="[""r"",""ind_f"",true]";
-												};
-											};
-										};
-										class Attribute1
 										{
 											property="TMF_SpecialistMarker";
 											expression="_this setVariable ['TMF_SpecialistMarker',_value,true];";
@@ -55027,64 +55507,26 @@ class Mission
 												};
 											};
 										};
+										class Attribute1
+										{
+											property="TMF_assignGear_faction";
+											expression="false";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"STRING"
+														};
+													};
+													value="example_loadout";
+												};
+											};
+										};
 										class Attribute2
-										{
-											property="speaker";
-											expression="_this setspeaker _value;";
-											class Value
-											{
-												class data
-												{
-													class type
-													{
-														type[]=
-														{
-															"STRING"
-														};
-													};
-													value="Male02GRE";
-												};
-											};
-										};
-										class Attribute3
-										{
-											property="pitch";
-											expression="_this setpitch _value;";
-											class Value
-											{
-												class data
-												{
-													class type
-													{
-														type[]=
-														{
-															"SCALAR"
-														};
-													};
-													value=1.02;
-												};
-											};
-										};
-										class Attribute4
-										{
-											property="TMF_Channellist";
-											expression="_this setVariable ['TMF_Channellist',_value,true];";
-											class Value
-											{
-												class data
-												{
-													class type
-													{
-														type[]=
-														{
-															"STRING"
-														};
-													};
-													value="[]";
-												};
-											};
-										};
-										class Attribute5
 										{
 											property="TMF_assignGear_enabled";
 											expression="false";
@@ -55103,13 +55545,89 @@ class Mission
 												};
 											};
 										};
-										nAttributes=6;
+										class Attribute3
+										{
+											property="TMF_Channellist";
+											expression="_this setVariable ['TMF_Channellist',_value,true];";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"STRING"
+														};
+													};
+													value="[]";
+												};
+											};
+										};
+										class Attribute4
+										{
+											property="pitch";
+											expression="_this setpitch _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"SCALAR"
+														};
+													};
+													value=1.02;
+												};
+											};
+										};
+										class Attribute5
+										{
+											property="speaker";
+											expression="_this setspeaker _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"STRING"
+														};
+													};
+													value="Male02GRE";
+												};
+											};
+										};
+										class Attribute6
+										{
+											property="TMF_assignGear_full";
+											expression="[_this,  _value] call TMF_assignGear_fnc_helper";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"STRING"
+														};
+													};
+													value="[""r"",""example_loadout"",true]";
+												};
+											};
+										};
+										nAttributes=7;
 									};
 								};
 							};
 							class Attributes
 							{
-								name="AAF_CO_GRP";
+								name="IND_CO_GRP";
 							};
 							id=1155;
 							class CustomAttributes
@@ -55155,7 +55673,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -55167,7 +55685,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="AAF CO";
+											value="INDFOR CO";
 										};
 									};
 								};
@@ -55231,8 +55749,8 @@ class Mission
 									class Attributes
 									{
 										rank="SERGEANT";
-										name="AAF_ASL_SL";
-										description="Squad Leader@AAF ASL";
+										name="IND_ASL_SL";
+										description="Squad Leader@INDFOR ASL";
 										isPlayable=1;
 									};
 									id=1160;
@@ -55273,7 +55791,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -55368,7 +55886,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""sl"",""ind_f"",true]";
+													value="[""sl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -55406,8 +55924,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="AAF_ASL_M";
-										description="Medic@AAF ASL";
+										name="IND_ASL_M";
+										description="Medic@INDFOR ASL";
 										isPlayable=1;
 									};
 									id=1161;
@@ -55448,7 +55966,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -55543,7 +56061,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""m"",""ind_f"",true]";
+													value="[""m"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -55572,7 +56090,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="AAF_ASL_GRP";
+								name="IND_ASL_GRP";
 							};
 							id=1159;
 							class CustomAttributes
@@ -55618,7 +56136,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -55630,7 +56148,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="AAF ASL";
+											value="INDFOR ASL";
 										};
 									};
 								};
@@ -55694,8 +56212,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="AAF_A1_FTL";
-										description="Fireteam Leader@AAF A1";
+										name="IND_A1_FTL";
+										description="Fireteam Leader@INDFOR A1";
 										isPlayable=1;
 									};
 									id=1163;
@@ -55736,7 +56254,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -55831,7 +56349,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ftl"",""ind_f"",true]";
+													value="[""ftl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -55868,8 +56386,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_A1_AR";
-										description="Autorifleman@AAF A1";
+										name="IND_A1_AR";
+										description="Autorifleman@INDFOR A1";
 										isPlayable=1;
 									};
 									id=1164;
@@ -55910,7 +56428,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -55986,7 +56504,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ar"",""ind_f"",true]";
+													value="[""ar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -56023,8 +56541,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_A1_AAR";
-										description="Asst. Autorifleman@AAF A1";
+										name="IND_A1_AAR";
+										description="Asst. Autorifleman@INDFOR A1";
 										isPlayable=1;
 									};
 									id=1165;
@@ -56065,7 +56583,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -56141,7 +56659,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""aar"",""ind_f"",true]";
+													value="[""aar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -56178,8 +56696,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_A1_RAT";
-										description="Rifleman (AT)@AAF A1";
+										name="IND_A1_RAT";
+										description="Rifleman (AT)@INDFOR A1";
 										isPlayable=1;
 									};
 									id=1166;
@@ -56220,7 +56738,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -56296,7 +56814,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""rat"",""ind_f"",true]";
+													value="[""rat"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -56333,8 +56851,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_A1_R";
-										description="Rifleman@AAF A1";
+										name="IND_A1_R";
+										description="Rifleman@INDFOR A1";
 										isPlayable=1;
 									};
 									id=1167;
@@ -56356,7 +56874,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""ind_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -56432,7 +56950,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -56469,8 +56987,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_A1_CLS";
-										description="Rifleman (CLS)@AAF A1";
+										name="IND_A1_CLS";
+										description="Rifleman (CLS)@INDFOR A1";
 										isPlayable=1;
 									};
 									id=1168;
@@ -56511,7 +57029,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -56587,7 +57105,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""cls"",""ind_f"",true]";
+													value="[""cls"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -56616,7 +57134,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="AAF_A1_GRP";
+								name="IND_A1_GRP";
 							};
 							id=1162;
 							class CustomAttributes
@@ -56662,7 +57180,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -56674,7 +57192,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="AAF A1";
+											value="INDFOR A1";
 										};
 									};
 								};
@@ -56738,8 +57256,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="AAF_A2_FTL";
-										description="Fireteam Leader@AAF A2";
+										name="IND_A2_FTL";
+										description="Fireteam Leader@INDFOR A2";
 										isPlayable=1;
 									};
 									id=1170;
@@ -56780,7 +57298,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -56875,7 +57393,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ftl"",""ind_f"",true]";
+													value="[""ftl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -56912,8 +57430,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_A2_AR";
-										description="Autorifleman@AAF A2";
+										name="IND_A2_AR";
+										description="Autorifleman@INDFOR A2";
 										isPlayable=1;
 									};
 									id=1171;
@@ -56954,7 +57472,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -57030,7 +57548,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ar"",""ind_f"",true]";
+													value="[""ar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -57067,8 +57585,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_A2_AAR";
-										description="Asst. Autorifleman@AAF A2";
+										name="IND_A2_AAR";
+										description="Asst. Autorifleman@INDFOR A2";
 										isPlayable=1;
 									};
 									id=1172;
@@ -57109,7 +57627,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -57185,7 +57703,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""aar"",""ind_f"",true]";
+													value="[""aar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -57222,8 +57740,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_A2_RAT";
-										description="Rifleman (AT)@AAF A2";
+										name="IND_A2_RAT";
+										description="Rifleman (AT)@INDFOR A2";
 										isPlayable=1;
 									};
 									id=1173;
@@ -57264,7 +57782,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -57340,7 +57858,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""rat"",""ind_f"",true]";
+													value="[""rat"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -57377,8 +57895,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_A2_R";
-										description="Rifleman@AAF A2";
+										name="IND_A2_R";
+										description="Rifleman@INDFOR A2";
 										isPlayable=1;
 									};
 									id=1174;
@@ -57400,7 +57918,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""ind_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -57476,7 +57994,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -57513,8 +58031,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_A2_CLS";
-										description="Rifleman (CLS)@AAF A2";
+										name="IND_A2_CLS";
+										description="Rifleman (CLS)@INDFOR A2";
 										isPlayable=1;
 									};
 									id=1175;
@@ -57555,7 +58073,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -57631,7 +58149,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""cls"",""ind_f"",true]";
+													value="[""cls"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -57660,7 +58178,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="AAF_A2_GRP";
+								name="IND_A2_GRP";
 							};
 							id=1169;
 							class CustomAttributes
@@ -57706,7 +58224,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -57718,7 +58236,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="AAF A2";
+											value="INDFOR A2";
 										};
 									};
 								};
@@ -57782,8 +58300,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="AAF_A3_FTL";
-										description="Fireteam Leader@AAF A3";
+										name="IND_A3_FTL";
+										description="Fireteam Leader@INDFOR A3";
 										isPlayable=1;
 									};
 									id=1177;
@@ -57824,7 +58342,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -57919,7 +58437,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ftl"",""ind_f"",true]";
+													value="[""ftl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -57956,8 +58474,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_A3_AR";
-										description="Autorifleman@AAF A3";
+										name="IND_A3_AR";
+										description="Autorifleman@INDFOR A3";
 										isPlayable=1;
 									};
 									id=1178;
@@ -57998,7 +58516,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -58074,7 +58592,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ar"",""ind_f"",true]";
+													value="[""ar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -58111,8 +58629,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_A3_AAR";
-										description="Asst. Autorifleman@AAF A3";
+										name="IND_A3_AAR";
+										description="Asst. Autorifleman@INDFOR A3";
 										isPlayable=1;
 									};
 									id=1179;
@@ -58153,7 +58671,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -58229,7 +58747,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""aar"",""ind_f"",true]";
+													value="[""aar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -58266,8 +58784,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_A3_RAT";
-										description="Rifleman (AT)@AAF A3";
+										name="IND_A3_RAT";
+										description="Rifleman (AT)@INDFOR A3";
 										isPlayable=1;
 									};
 									id=1180;
@@ -58308,7 +58826,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -58384,7 +58902,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""rat"",""ind_f"",true]";
+													value="[""rat"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -58421,8 +58939,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_A3_R";
-										description="Rifleman@AAF A3";
+										name="IND_A3_R";
+										description="Rifleman@INDFOR A3";
 										isPlayable=1;
 									};
 									id=1181;
@@ -58444,7 +58962,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""ind_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -58520,7 +59038,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -58557,8 +59075,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_A3_CLS";
-										description="Rifleman (CLS)@AAF A3";
+										name="IND_A3_CLS";
+										description="Rifleman (CLS)@INDFOR A3";
 										isPlayable=1;
 									};
 									id=1182;
@@ -58599,7 +59117,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -58675,7 +59193,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""cls"",""ind_f"",true]";
+													value="[""cls"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -58704,7 +59222,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="AAF_A3_GRP";
+								name="IND_A3_GRP";
 							};
 							id=1176;
 							class CustomAttributes
@@ -58750,7 +59268,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -58762,7 +59280,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="AAF A3";
+											value="INDFOR A3";
 										};
 									};
 								};
@@ -58826,8 +59344,8 @@ class Mission
 									class Attributes
 									{
 										rank="SERGEANT";
-										name="AAF_BSL_SL";
-										description="Squad Leader@AAF BSL";
+										name="IND_BSL_SL";
+										description="Squad Leader@INDFOR BSL";
 										isPlayable=1;
 									};
 									id=1184;
@@ -58868,7 +59386,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -58963,7 +59481,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""sl"",""ind_f"",true]";
+													value="[""sl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -59001,8 +59519,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="AAF_BSL_M";
-										description="Medic@AAF BSL";
+										name="IND_BSL_M";
+										description="Medic@INDFOR BSL";
 										isPlayable=1;
 									};
 									id=1185;
@@ -59043,7 +59561,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -59138,7 +59656,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""m"",""ind_f"",true]";
+													value="[""m"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -59167,7 +59685,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="AAF_BSL_GRP";
+								name="IND_BSL_GRP";
 							};
 							id=1183;
 							class CustomAttributes
@@ -59213,7 +59731,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -59225,7 +59743,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="AAF BSL";
+											value="INDFOR BSL";
 										};
 									};
 								};
@@ -59289,8 +59807,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="AAF_B1_FTL";
-										description="Fireteam Leader@AAF B1";
+										name="IND_B1_FTL";
+										description="Fireteam Leader@INDFOR B1";
 										isPlayable=1;
 									};
 									id=1187;
@@ -59331,7 +59849,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -59426,7 +59944,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ftl"",""ind_f"",true]";
+													value="[""ftl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -59463,8 +59981,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_B1_AR";
-										description="Autorifleman@AAF B1";
+										name="IND_B1_AR";
+										description="Autorifleman@INDFOR B1";
 										isPlayable=1;
 									};
 									id=1188;
@@ -59505,7 +60023,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -59581,7 +60099,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ar"",""ind_f"",true]";
+													value="[""ar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -59618,8 +60136,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_B1_AAR";
-										description="Asst. Autorifleman@AAF B1";
+										name="IND_B1_AAR";
+										description="Asst. Autorifleman@INDFOR B1";
 										isPlayable=1;
 									};
 									id=1189;
@@ -59660,7 +60178,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -59736,7 +60254,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""aar"",""ind_f"",true]";
+													value="[""aar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -59773,8 +60291,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_B1_RAT";
-										description="Rifleman (AT)@AAF B1";
+										name="IND_B1_RAT";
+										description="Rifleman (AT)@INDFOR B1";
 										isPlayable=1;
 									};
 									id=1190;
@@ -59815,7 +60333,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -59891,7 +60409,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""rat"",""ind_f"",true]";
+													value="[""rat"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -59928,8 +60446,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_B1_R";
-										description="Rifleman@AAF B1";
+										name="IND_B1_R";
+										description="Rifleman@INDFOR B1";
 										isPlayable=1;
 									};
 									id=1191;
@@ -59951,7 +60469,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""ind_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -60027,7 +60545,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -60064,8 +60582,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_B1_CLS";
-										description="Rifleman (CLS)@AAF B1";
+										name="IND_B1_CLS";
+										description="Rifleman (CLS)@INDFOR B1";
 										isPlayable=1;
 									};
 									id=1192;
@@ -60106,7 +60624,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -60182,7 +60700,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""cls"",""ind_f"",true]";
+													value="[""cls"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -60211,7 +60729,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="AAF_B1_GRP";
+								name="IND_B1_GRP";
 							};
 							id=1186;
 							class CustomAttributes
@@ -60257,7 +60775,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -60269,7 +60787,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="AAF B1";
+											value="INDFOR B1";
 										};
 									};
 								};
@@ -60333,8 +60851,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="AAF_B2_FTL";
-										description="Fireteam Leader@AAF B2";
+										name="IND_B2_FTL";
+										description="Fireteam Leader@INDFOR B2";
 										isPlayable=1;
 									};
 									id=1194;
@@ -60375,7 +60893,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -60470,7 +60988,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ftl"",""ind_f"",true]";
+													value="[""ftl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -60507,8 +61025,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_B2_AR";
-										description="Autorifleman@AAF B2";
+										name="IND_B2_AR";
+										description="Autorifleman@INDFOR B2";
 										isPlayable=1;
 									};
 									id=1195;
@@ -60549,7 +61067,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -60625,7 +61143,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ar"",""ind_f"",true]";
+													value="[""ar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -60662,8 +61180,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_B2_AAR";
-										description="Asst. Autorifleman@AAF B2";
+										name="IND_B2_AAR";
+										description="Asst. Autorifleman@INDFOR B2";
 										isPlayable=1;
 									};
 									id=1196;
@@ -60704,7 +61222,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -60780,7 +61298,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""aar"",""ind_f"",true]";
+													value="[""aar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -60817,8 +61335,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_B2_RAT";
-										description="Rifleman (AT)@AAF B2";
+										name="IND_B2_RAT";
+										description="Rifleman (AT)@INDFOR B2";
 										isPlayable=1;
 									};
 									id=1197;
@@ -60859,7 +61377,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -60935,7 +61453,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""rat"",""ind_f"",true]";
+													value="[""rat"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -60972,8 +61490,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_B2_R";
-										description="Rifleman@AAF B2";
+										name="IND_B2_R";
+										description="Rifleman@INDFOR B2";
 										isPlayable=1;
 									};
 									id=1198;
@@ -60995,7 +61513,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""ind_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -61071,7 +61589,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -61108,8 +61626,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_B2_CLS";
-										description="Rifleman (CLS)@AAF B2";
+										name="IND_B2_CLS";
+										description="Rifleman (CLS)@INDFOR B2";
 										isPlayable=1;
 									};
 									id=1199;
@@ -61150,7 +61668,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -61226,7 +61744,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""cls"",""ind_f"",true]";
+													value="[""cls"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -61255,7 +61773,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="AAF_B2_GRP";
+								name="IND_B2_GRP";
 							};
 							id=1193;
 							class CustomAttributes
@@ -61301,7 +61819,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -61313,7 +61831,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="AAF B2";
+											value="INDFOR B2";
 										};
 									};
 								};
@@ -61377,8 +61895,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="AAF_B3_FTL";
-										description="Fireteam Leader@AAF B3";
+										name="IND_B3_FTL";
+										description="Fireteam Leader@INDFOR B3";
 										isPlayable=1;
 									};
 									id=1201;
@@ -61419,7 +61937,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -61514,7 +62032,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ftl"",""ind_f"",true]";
+													value="[""ftl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -61551,8 +62069,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_B3_AR";
-										description="Autorifleman@AAF B3";
+										name="IND_B3_AR";
+										description="Autorifleman@INDFOR B3";
 										isPlayable=1;
 									};
 									id=1202;
@@ -61593,7 +62111,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -61669,7 +62187,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ar"",""ind_f"",true]";
+													value="[""ar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -61706,8 +62224,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_B3_AAR";
-										description="Asst. Autorifleman@AAF B3";
+										name="IND_B3_AAR";
+										description="Asst. Autorifleman@INDFOR B3";
 										isPlayable=1;
 									};
 									id=1203;
@@ -61748,7 +62266,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -61824,7 +62342,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""aar"",""ind_f"",true]";
+													value="[""aar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -61861,8 +62379,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_B3_RAT";
-										description="Rifleman (AT)@AAF B3";
+										name="IND_B3_RAT";
+										description="Rifleman (AT)@INDFOR B3";
 										isPlayable=1;
 									};
 									id=1204;
@@ -61903,7 +62421,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -61979,7 +62497,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""rat"",""ind_f"",true]";
+													value="[""rat"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -62016,8 +62534,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_B3_R";
-										description="Rifleman@AAF B3";
+										name="IND_B3_R";
+										description="Rifleman@INDFOR B3";
 										isPlayable=1;
 									};
 									id=1205;
@@ -62039,7 +62557,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""ind_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -62115,7 +62633,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -62152,8 +62670,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_B3_CLS";
-										description="Rifleman (CLS)@AAF B3";
+										name="IND_B3_CLS";
+										description="Rifleman (CLS)@INDFOR B3";
 										isPlayable=1;
 									};
 									id=1206;
@@ -62194,7 +62712,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -62270,7 +62788,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""cls"",""ind_f"",true]";
+													value="[""cls"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -62299,7 +62817,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="AAF_B3_GRP";
+								name="IND_B3_GRP";
 							};
 							id=1200;
 							class CustomAttributes
@@ -62345,7 +62863,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -62357,7 +62875,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="AAF B3";
+											value="INDFOR B3";
 										};
 									};
 								};
@@ -62421,8 +62939,8 @@ class Mission
 									class Attributes
 									{
 										rank="SERGEANT";
-										name="AAF_CSL_SL";
-										description="Squad Leader@AAF CSL";
+										name="IND_CSL_SL";
+										description="Squad Leader@INDFOR CSL";
 										isPlayable=1;
 									};
 									id=1208;
@@ -62463,7 +62981,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -62558,7 +63076,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""sl"",""ind_f"",true]";
+													value="[""sl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -62596,8 +63114,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="AAF_CSL_M";
-										description="Medic@AAF CSL";
+										name="IND_CSL_M";
+										description="Medic@INDFOR CSL";
 										isPlayable=1;
 									};
 									id=1209;
@@ -62638,7 +63156,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -62733,7 +63251,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""m"",""ind_f"",true]";
+													value="[""m"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -62762,7 +63280,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="AAF_CSL_GRP";
+								name="IND_CSL_GRP";
 							};
 							id=1207;
 							class CustomAttributes
@@ -62808,7 +63326,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -62820,7 +63338,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="AAF CSL";
+											value="INDFOR CSL";
 										};
 									};
 								};
@@ -62884,8 +63402,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="AAF_C1_FTL";
-										description="Fireteam Leader@AAF C1";
+										name="IND_C1_FTL";
+										description="Fireteam Leader@INDFOR C1";
 										isPlayable=1;
 									};
 									id=1211;
@@ -62926,7 +63444,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -63021,7 +63539,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ftl"",""ind_f"",true]";
+													value="[""ftl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -63058,8 +63576,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_C1_AR";
-										description="Autorifleman@AAF C1";
+										name="IND_C1_AR";
+										description="Autorifleman@INDFOR C1";
 										isPlayable=1;
 									};
 									id=1212;
@@ -63100,7 +63618,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -63176,7 +63694,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ar"",""ind_f"",true]";
+													value="[""ar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -63213,8 +63731,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_C1_AAR";
-										description="Asst. Autorifleman@AAF C1";
+										name="IND_C1_AAR";
+										description="Asst. Autorifleman@INDFOR C1";
 										isPlayable=1;
 									};
 									id=1213;
@@ -63255,7 +63773,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -63331,7 +63849,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""aar"",""ind_f"",true]";
+													value="[""aar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -63368,8 +63886,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_C1_RAT";
-										description="Rifleman (AT)@AAF C1";
+										name="IND_C1_RAT";
+										description="Rifleman (AT)@INDFOR C1";
 										isPlayable=1;
 									};
 									id=1214;
@@ -63410,7 +63928,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -63486,7 +64004,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""rat"",""ind_f"",true]";
+													value="[""rat"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -63523,8 +64041,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_C1_R";
-										description="Rifleman@AAF C1";
+										name="IND_C1_R";
+										description="Rifleman@INDFOR C1";
 										isPlayable=1;
 									};
 									id=1215;
@@ -63546,7 +64064,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""ind_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -63622,7 +64140,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -63659,8 +64177,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_C1_CLS";
-										description="Rifleman (CLS)@AAF C1";
+										name="IND_C1_CLS";
+										description="Rifleman (CLS)@INDFOR C1";
 										isPlayable=1;
 									};
 									id=1216;
@@ -63701,7 +64219,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -63777,7 +64295,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""cls"",""ind_f"",true]";
+													value="[""cls"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -63806,7 +64324,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="AAF_C1_GRP";
+								name="IND_C1_GRP";
 							};
 							id=1210;
 							class CustomAttributes
@@ -63852,7 +64370,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -63864,7 +64382,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="AAF C1";
+											value="INDFOR C1";
 										};
 									};
 								};
@@ -63928,8 +64446,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="AAF_C2_FTL";
-										description="Fireteam Leader@AAF C2";
+										name="IND_C2_FTL";
+										description="Fireteam Leader@INDFOR C2";
 										isPlayable=1;
 									};
 									id=1218;
@@ -63970,7 +64488,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -64065,7 +64583,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ftl"",""ind_f"",true]";
+													value="[""ftl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -64102,8 +64620,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_C2_AR";
-										description="Autorifleman@AAF C2";
+										name="IND_C2_AR";
+										description="Autorifleman@INDFOR C2";
 										isPlayable=1;
 									};
 									id=1219;
@@ -64144,7 +64662,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -64220,7 +64738,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ar"",""ind_f"",true]";
+													value="[""ar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -64257,8 +64775,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_C2_AAR";
-										description="Asst. Autorifleman@AAF C2";
+										name="IND_C2_AAR";
+										description="Asst. Autorifleman@INDFOR C2";
 										isPlayable=1;
 									};
 									id=1220;
@@ -64299,7 +64817,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -64375,7 +64893,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""aar"",""ind_f"",true]";
+													value="[""aar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -64412,8 +64930,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_C2_RAT";
-										description="Rifleman (AT)@AAF C2";
+										name="IND_C2_RAT";
+										description="Rifleman (AT)@INDFOR C2";
 										isPlayable=1;
 									};
 									id=1221;
@@ -64454,7 +64972,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -64530,7 +65048,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""rat"",""ind_f"",true]";
+													value="[""rat"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -64567,8 +65085,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_C2_R";
-										description="Rifleman@AAF C2";
+										name="IND_C2_R";
+										description="Rifleman@INDFOR C2";
 										isPlayable=1;
 									};
 									id=1222;
@@ -64590,7 +65108,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""ind_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -64666,7 +65184,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -64703,8 +65221,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_C2_CLS";
-										description="Rifleman (CLS)@AAF C2";
+										name="IND_C2_CLS";
+										description="Rifleman (CLS)@INDFOR C2";
 										isPlayable=1;
 									};
 									id=1223;
@@ -64745,7 +65263,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -64821,7 +65339,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""cls"",""ind_f"",true]";
+													value="[""cls"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -64850,7 +65368,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="AAF_C2_GRP";
+								name="IND_C2_GRP";
 							};
 							id=1217;
 							class CustomAttributes
@@ -64896,7 +65414,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -64908,7 +65426,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="AAF C2";
+											value="INDFOR C2";
 										};
 									};
 								};
@@ -64972,8 +65490,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="AAF_C3_FTL";
-										description="Fireteam Leader@AAF C3";
+										name="IND_C3_FTL";
+										description="Fireteam Leader@INDFOR C3";
 										isPlayable=1;
 									};
 									id=1225;
@@ -65014,7 +65532,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -65109,7 +65627,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ftl"",""ind_f"",true]";
+													value="[""ftl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -65146,8 +65664,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_C3_AR";
-										description="Autorifleman@AAF C3";
+										name="IND_C3_AR";
+										description="Autorifleman@INDFOR C3";
 										isPlayable=1;
 									};
 									id=1226;
@@ -65188,7 +65706,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -65264,7 +65782,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""ar"",""ind_f"",true]";
+													value="[""ar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -65301,8 +65819,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_C3_AAR";
-										description="Asst. Autorifleman@AAF C3";
+										name="IND_C3_AAR";
+										description="Asst. Autorifleman@INDFOR C3";
 										isPlayable=1;
 									};
 									id=1227;
@@ -65343,7 +65861,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -65419,7 +65937,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""aar"",""ind_f"",true]";
+													value="[""aar"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -65456,8 +65974,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_C3_RAT";
-										description="Rifleman (AT)@AAF C3";
+										name="IND_C3_RAT";
+										description="Rifleman (AT)@INDFOR C3";
 										isPlayable=1;
 									};
 									id=1228;
@@ -65498,7 +66016,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -65574,7 +66092,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""rat"",""ind_f"",true]";
+													value="[""rat"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -65611,8 +66129,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_C3_R";
-										description="Rifleman@AAF C3";
+										name="IND_C3_R";
+										description="Rifleman@INDFOR C3";
 										isPlayable=1;
 									};
 									id=1229;
@@ -65634,7 +66152,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""ind_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -65710,7 +66228,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -65747,8 +66265,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_C3_CLS";
-										description="Rifleman (CLS)@AAF C3";
+										name="IND_C3_CLS";
+										description="Rifleman (CLS)@INDFOR C3";
 										isPlayable=1;
 									};
 									id=1230;
@@ -65789,7 +66307,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -65865,7 +66383,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""cls"",""ind_f"",true]";
+													value="[""cls"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -65894,7 +66412,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="AAF_C3_GRP";
+								name="IND_C3_GRP";
 							};
 							id=1224;
 							class CustomAttributes
@@ -65940,7 +66458,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -65952,7 +66470,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="AAF C3";
+											value="INDFOR C3";
 										};
 									};
 								};
@@ -66016,8 +66534,8 @@ class Mission
 									class Attributes
 									{
 										rank="SERGEANT";
-										name="AAF_WSL_SL";
-										description="Squad Leader@AAF WSL";
+										name="IND_WSL_SL";
+										description="Squad Leader@INDFOR WSL";
 										isPlayable=1;
 									};
 									id=1232;
@@ -66058,7 +66576,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -66153,7 +66671,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""sl"",""ind_f"",true]";
+													value="[""sl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -66191,8 +66709,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="AAF_WSL_M";
-										description="Medic@AAF WSL";
+										name="IND_WSL_M";
+										description="Medic@INDFOR WSL";
 										isPlayable=1;
 									};
 									id=1233;
@@ -66233,7 +66751,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -66328,7 +66846,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""m"",""ind_f"",true]";
+													value="[""m"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -66357,7 +66875,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="AAF_WSL_GRP";
+								name="IND_WSL_GRP";
 							};
 							id=1231;
 							class CustomAttributes
@@ -66377,7 +66895,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -66403,7 +66921,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -66415,7 +66933,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="AAF WSL";
+											value="INDFOR WSL";
 										};
 									};
 								};
@@ -66479,8 +66997,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="AAF_MMG1_MMGTL";
-										description="Team Leader@AAF MMG1";
+										name="IND_MMG1_MMGTL";
+										description="Team Leader@INDFOR MMG1";
 										isPlayable=1;
 									};
 									id=1235;
@@ -66521,7 +67039,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -66635,7 +67153,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""mmgtl"",""ind_f"",true]";
+													value="[""mmgtl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -66672,8 +67190,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_MMG1_MMGG";
-										description="Gunner@AAF MMG1";
+										name="IND_MMG1_MMGG";
+										description="Gunner@INDFOR MMG1";
 										isPlayable=1;
 									};
 									id=1594;
@@ -66714,7 +67232,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -66828,7 +67346,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""mmgg"",""ind_f"",true]";
+													value="[""mmgg"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -66865,8 +67383,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_MMG1_MMGAC";
-										description="Ammocarrier@AAF MMG1";
+										name="IND_MMG1_MMGAC";
+										description="Ammocarrier@INDFOR MMG1";
 										isPlayable=1;
 									};
 									id=1236;
@@ -66907,7 +67425,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -67021,7 +67539,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""mmgac"",""ind_f"",true]";
+													value="[""mmgac"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -67050,7 +67568,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="AAF_MMG1_GRP";
+								name="IND_MMG1_GRP";
 							};
 							id=1234;
 							class CustomAttributes
@@ -67070,7 +67588,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -67096,7 +67614,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -67108,7 +67626,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="AAF MMG1";
+											value="INDFOR MMG1";
 										};
 									};
 								};
@@ -67172,8 +67690,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="AAF_MMG2_MMGTL";
-										description="Team Leader@AAF MMG1";
+										name="IND_MMG2_MMGTL";
+										description="Team Leader@INDFOR MMG1";
 										isPlayable=1;
 									};
 									id=1484;
@@ -67214,7 +67732,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -67328,7 +67846,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""mmgtl"",""ind_f"",true]";
+													value="[""mmgtl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -67365,8 +67883,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_MMG2_MMGG";
-										description="Gunner@AAF MMG2";
+										name="IND_MMG2_MMGG";
+										description="Gunner@INDFOR MMG2";
 										isPlayable=1;
 									};
 									id=1596;
@@ -67407,7 +67925,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -67521,7 +68039,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""mmgg"",""ind_f"",true]";
+													value="[""mmgg"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -67558,8 +68076,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_MMG2_MMGAC";
-										description="Ammocarrier@AAF MMG1";
+										name="IND_MMG2_MMGAC";
+										description="Ammocarrier@INDFOR MMG1";
 										isPlayable=1;
 									};
 									id=1485;
@@ -67600,7 +68118,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -67714,7 +68232,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""mmgac"",""ind_f"",true]";
+													value="[""mmgac"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -67743,7 +68261,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="AAF_MMG2_GRP";
+								name="IND_MMG2_GRP";
 							};
 							id=1483;
 							class CustomAttributes
@@ -67763,7 +68281,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -67789,7 +68307,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -67801,7 +68319,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="AAF MMG2";
+											value="INDFOR MMG2";
 										};
 									};
 								};
@@ -67865,8 +68383,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="AAF_HMG1_HMGTL";
-										description="Team Leader@AAF HMG1";
+										name="IND_HMG1_HMGTL";
+										description="Team Leader@INDFOR HMG1";
 										isPlayable=1;
 									};
 									id=1487;
@@ -67907,7 +68425,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -68040,7 +68558,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hmgtl"",""ind_f"",true]";
+													value="[""hmgtl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -68077,8 +68595,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_HMG1_HMGAC";
-										description="Ammocarrier@AAF HMG1";
+										name="IND_HMG1_HMGAC";
+										description="Ammocarrier@INDFOR HMG1";
 										isPlayable=1;
 									};
 									id=1488;
@@ -68119,7 +68637,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -68252,7 +68770,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hmgac"",""ind_f"",true]";
+													value="[""hmgac"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -68289,8 +68807,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_HMG1_HMGG";
-										description="Gunner@AAF HMG1";
+										name="IND_HMG1_HMGG";
+										description="Gunner@INDFOR HMG1";
 										isPlayable=1;
 									};
 									id=1501;
@@ -68331,7 +68849,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -68464,7 +68982,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hmgg"",""ind_f"",true]";
+													value="[""hmgg"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -68493,7 +69011,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="AAF_HMG1_GRP";
+								name="IND_HMG1_GRP";
 							};
 							id=1486;
 							class CustomAttributes
@@ -68513,7 +69031,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -68539,7 +69057,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -68551,7 +69069,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="AAF HMG1";
+											value="INDFOR HMG1";
 										};
 									};
 								};
@@ -68615,8 +69133,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="AAF_HMG2_HMGTL";
-										description="Team Leader@AAF HMG2";
+										name="IND_HMG2_HMGTL";
+										description="Team Leader@INDFOR HMG2";
 										isPlayable=1;
 									};
 									id=1498;
@@ -68657,7 +69175,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -68790,7 +69308,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hmgtl"",""ind_f"",true]";
+													value="[""hmgtl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -68827,8 +69345,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_HMG2_HMGAC";
-										description="Ammocarrier@AAF HMG2";
+										name="IND_HMG2_HMGAC";
+										description="Ammocarrier@INDFOR HMG2";
 										isPlayable=1;
 									};
 									id=1499;
@@ -68869,7 +69387,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -69002,7 +69520,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hmgac"",""ind_f"",true]";
+													value="[""hmgac"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -69039,8 +69557,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_HMG2_HMGG";
-										description="Gunner@AAF HMG2";
+										name="IND_HMG2_HMGG";
+										description="Gunner@INDFOR HMG2";
 										isPlayable=1;
 									};
 									id=1503;
@@ -69081,7 +69599,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -69214,7 +69732,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hmgg"",""ind_f"",true]";
+													value="[""hmgg"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -69243,7 +69761,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="AAF_HMG2_GRP";
+								name="IND_HMG2_GRP";
 							};
 							id=1497;
 							class CustomAttributes
@@ -69263,7 +69781,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -69289,7 +69807,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -69301,7 +69819,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="AAF HMG2";
+											value="INDFOR HMG2";
 										};
 									};
 								};
@@ -69365,8 +69883,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="AAF_MAT1_MATTL";
-										description="Team Leader@AAF MAT1";
+										name="IND_MAT1_MATTL";
+										description="Team Leader@INDFOR MAT1";
 										isPlayable=1;
 									};
 									id=1249;
@@ -69407,7 +69925,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -69521,7 +70039,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""mattl"",""ind_f"",true]";
+													value="[""mattl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -69558,8 +70076,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_MAT1_MATG";
-										description="Gunner@AAF MAT1";
+										name="IND_MAT1_MATG";
+										description="Gunner@INDFOR MAT1";
 										isPlayable=1;
 									};
 									id=1250;
@@ -69600,7 +70118,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -69714,7 +70232,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""matg"",""ind_f"",true]";
+													value="[""matg"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -69751,8 +70269,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_MAT1_MATAC";
-										description="Ammocarrier@AAF MAT1";
+										name="IND_MAT1_MATAC";
+										description="Ammocarrier@INDFOR MAT1";
 										isPlayable=1;
 									};
 									id=1251;
@@ -69793,7 +70311,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -69907,7 +70425,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""matac"",""ind_f"",true]";
+													value="[""matac"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -69936,7 +70454,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="AAF_MAT1_GRP";
+								name="IND_MAT1_GRP";
 							};
 							id=1248;
 							class CustomAttributes
@@ -69956,7 +70474,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -69982,7 +70500,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -69994,7 +70512,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="AAF MAT1";
+											value="INDFOR MAT1";
 										};
 									};
 								};
@@ -70058,8 +70576,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="AAF_MAT2_MATTL";
-										description="Team Leader@AAF MAT1";
+										name="IND_MAT2_MATTL";
+										description="Team Leader@INDFOR MAT1";
 										isPlayable=1;
 									};
 									id=1480;
@@ -70100,7 +70618,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -70214,7 +70732,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""mattl"",""ind_f"",true]";
+													value="[""mattl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -70251,8 +70769,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_MAT2_MATG";
-										description="Gunner@AAF MAT1";
+										name="IND_MAT2_MATG";
+										description="Gunner@INDFOR MAT1";
 										isPlayable=1;
 									};
 									id=1481;
@@ -70293,7 +70811,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -70407,7 +70925,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""matg"",""ind_f"",true]";
+													value="[""matg"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -70444,8 +70962,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_MAT2_MATAC";
-										description="Ammocarrier@AAF MAT1";
+										name="IND_MAT2_MATAC";
+										description="Ammocarrier@INDFOR MAT1";
 										isPlayable=1;
 									};
 									id=1482;
@@ -70486,7 +71004,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -70600,7 +71118,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""matac"",""ind_f"",true]";
+													value="[""matac"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -70629,7 +71147,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="AAF_MAT2_GRP";
+								name="IND_MAT2_GRP";
 							};
 							id=1479;
 							class CustomAttributes
@@ -70649,7 +71167,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -70675,7 +71193,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -70687,7 +71205,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="AAF MAT2";
+											value="INDFOR MAT2";
 										};
 									};
 								};
@@ -70751,8 +71269,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="AAF_HAT1_HATTL";
-										description="Team Leader@AAF HAT1";
+										name="IND_HAT1_HATTL";
+										description="Team Leader@INDFOR HAT1";
 										isPlayable=1;
 									};
 									id=1490;
@@ -70793,7 +71311,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -70907,7 +71425,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hattl"",""ind_f"",true]";
+													value="[""hattl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -70944,8 +71462,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_HAT1_HATG";
-										description="Gunner@AAF HAT1";
+										name="IND_HAT1_HATG";
+										description="Gunner@INDFOR HAT1";
 										isPlayable=1;
 									};
 									id=1491;
@@ -70986,7 +71504,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -71100,7 +71618,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hatg"",""ind_f"",true]";
+													value="[""hatg"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -71137,8 +71655,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_HAT1_HATAC";
-										description="Ammocarrier@AAF HAT1";
+										name="IND_HAT1_HATAC";
+										description="Ammocarrier@INDFOR HAT1";
 										isPlayable=1;
 									};
 									id=1492;
@@ -71179,7 +71697,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -71293,7 +71811,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hatac"",""ind_f"",true]";
+													value="[""hatac"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -71322,7 +71840,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="AAF_HAT1_GRP";
+								name="IND_HAT1_GRP";
 							};
 							id=1489;
 							class CustomAttributes
@@ -71342,7 +71860,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -71368,7 +71886,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -71380,7 +71898,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="AAF HAT1";
+											value="INDFOR HAT1";
 										};
 									};
 								};
@@ -71444,8 +71962,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="AAF_HAT2_HATTL";
-										description="Team Leader@AAF HAT2";
+										name="IND_HAT2_HATTL";
+										description="Team Leader@INDFOR HAT2";
 										isPlayable=1;
 									};
 									id=1494;
@@ -71486,7 +72004,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -71600,7 +72118,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hattl"",""ind_f"",true]";
+													value="[""hattl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -71637,8 +72155,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_HAT2_HATG";
-										description="Gunner@AAF HAT2";
+										name="IND_HAT2_HATG";
+										description="Gunner@INDFOR HAT2";
 										isPlayable=1;
 									};
 									id=1495;
@@ -71679,7 +72197,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -71793,7 +72311,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hatg"",""ind_f"",true]";
+													value="[""hatg"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -71830,8 +72348,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_HAT2_HATAC";
-										description="Ammocarrier@AAF HAT2";
+										name="IND_HAT2_HATAC";
+										description="Ammocarrier@INDFOR HAT2";
 										isPlayable=1;
 									};
 									id=1496;
@@ -71872,7 +72390,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -71986,7 +72504,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hatac"",""ind_f"",true]";
+													value="[""hatac"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -72015,7 +72533,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="AAF_HAT2_GRP";
+								name="IND_HAT2_GRP";
 							};
 							id=1493;
 							class CustomAttributes
@@ -72035,7 +72553,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -72061,7 +72579,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -72073,7 +72591,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="AAF HAT2";
+											value="INDFOR HAT2";
 										};
 									};
 								};
@@ -72137,8 +72655,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="AAF_MANPADS_SAMAG";
-										description="Team Leader@AAF MANPADS";
+										name="IND_MANPADS_SAMAG";
+										description="Team Leader@INDFOR MANPADS";
 										isPlayable=1;
 									};
 									id=1265;
@@ -72179,7 +72697,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -72274,7 +72792,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""samag"",""ind_f"",true]";
+													value="[""samag"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -72311,8 +72829,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_MANPADS_SAMG";
-										description="Gunner@AAF MANPADS";
+										name="IND_MANPADS_SAMG";
+										description="Gunner@INDFOR MANPADS";
 										isPlayable=1;
 									};
 									id=1266;
@@ -72353,7 +72871,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -72467,7 +72985,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""samg"",""ind_f"",true]";
+													value="[""samg"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -72496,7 +73014,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="AAF_MANPADS_GRP";
+								name="IND_MANPADS_GRP";
 							};
 							id=1264;
 							class CustomAttributes
@@ -72516,7 +73034,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -72542,7 +73060,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -72554,7 +73072,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="AAF MANPADS";
+											value="INDFOR MANPADS";
 										};
 									};
 								};
@@ -72618,8 +73136,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="AAF_MTR_MTRTL";
-										description="Team Leader@AAF MTR";
+										name="IND_MTR_MTRTL";
+										description="Team Leader@INDFOR MTR";
 										isPlayable=1;
 									};
 									id=1268;
@@ -72660,7 +73178,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -72774,7 +73292,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""mtrtl"",""ind_f"",true]";
+													value="[""mtrtl"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -72811,8 +73329,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_MTR_MTRG";
-										description="Gunner@AAF MTR";
+										name="IND_MTR_MTRG";
+										description="Gunner@INDFOR MTR";
 										isPlayable=1;
 									};
 									id=1269;
@@ -72853,7 +73371,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -72967,7 +73485,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""mtrg"",""ind_f"",true]";
+													value="[""mtrg"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -73004,8 +73522,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_MTR_MTRAC";
-										description="Ammocarrier@AAF MTR";
+										name="IND_MTR_MTRAC";
+										description="Ammocarrier@INDFOR MTR";
 										isPlayable=1;
 									};
 									id=1270;
@@ -73046,7 +73564,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -73141,7 +73659,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""mtrac"",""ind_f"",true]";
+													value="[""mtrac"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -73170,7 +73688,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="AAF_MTR_GRP";
+								name="IND_MTR_GRP";
 							};
 							id=1267;
 							class CustomAttributes
@@ -73190,7 +73708,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -73216,7 +73734,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -73228,7 +73746,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="AAF MTR";
+											value="INDFOR MTR";
 										};
 									};
 								};
@@ -73292,8 +73810,8 @@ class Mission
 									class Attributes
 									{
 										rank="LIEUTENANT";
-										name="AAF_SN_SP";
-										description="Spotter@AAF SN";
+										name="IND_SN_SP";
+										description="Spotter@INDFOR SN";
 										isPlayable=1;
 									};
 									id=1277;
@@ -73334,7 +73852,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -73429,7 +73947,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""sp"",""ind_f"",true]";
+													value="[""sp"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -73467,8 +73985,8 @@ class Mission
 									class Attributes
 									{
 										rank="SERGEANT";
-										name="AAF_SN_SN";
-										description="Sniper@AAF SN";
+										name="IND_SN_SN";
+										description="Sniper@INDFOR SN";
 										isPlayable=1;
 									};
 									id=1278;
@@ -73509,7 +74027,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -73623,7 +74141,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""sn"",""ind_f"",true]";
+													value="[""sn"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -73652,7 +74170,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="AAF_SN_GRP";
+								name="IND_SN_GRP";
 							};
 							id=1276;
 							class CustomAttributes
@@ -73672,7 +74190,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -73698,7 +74216,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -73710,7 +74228,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="AAF SN";
+											value="INDFOR SN";
 										};
 									};
 								};
@@ -73770,16 +74288,16 @@ class Mission
 										position[]={83,5.0014391,28.049999};
 									};
 									side="Independent";
-									flags=7;
+									flags=6;
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="AAF_ENG_ENG1";
-										description="Engineer Leader (Explosives)@AAF ENG";
+										name="IND_LOGI_LOGI1";
+										description="Team Leader@INDFOR LOGI";
 										isPlayable=1;
 									};
-									id=1272;
-									type="I_Soldier_exp_F";
+									id=1616;
+									type="I_engineer_F";
 									class CustomAttributes
 									{
 										class Attribute0
@@ -73816,7 +74334,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -73841,6 +74359,25 @@ class Mission
 										};
 										class Attribute3
 										{
+											property="face";
+											expression="_this setface _value;";
+											class Value
+											{
+												class data
+												{
+													class type
+													{
+														type[]=
+														{
+															"STRING"
+														};
+													};
+													value="AfricanHead_03";
+												};
+											};
+										};
+										class Attribute4
+										{
 											property="TMF_Channellist";
 											expression="_this setVariable ['TMF_Channellist',_value,true];";
 											class Value
@@ -73858,7 +74395,7 @@ class Mission
 												};
 											};
 										};
-										class Attribute4
+										class Attribute5
 										{
 											property="pitch";
 											expression="_this setpitch _value;";
@@ -73877,7 +74414,7 @@ class Mission
 												};
 											};
 										};
-										class Attribute5
+										class Attribute6
 										{
 											property="speaker";
 											expression="_this setspeaker _value;";
@@ -73896,7 +74433,7 @@ class Mission
 												};
 											};
 										};
-										class Attribute6
+										class Attribute7
 										{
 											property="TMF_assignGear_full";
 											expression="[_this,  _value] call TMF_assignGear_fnc_helper";
@@ -73911,11 +74448,11 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""eng"",""ind_f"",true]";
+													value="[""logi"",""example_loadout"",true]";
 												};
 											};
 										};
-										class Attribute7
+										class Attribute8
 										{
 											property="TMF_assignGear_role";
 											expression="false";
@@ -73930,11 +74467,11 @@ class Mission
 															"STRING"
 														};
 													};
-													value="eng";
+													value="logi";
 												};
 											};
 										};
-										nAttributes=8;
+										nAttributes=9;
 									};
 								};
 								class Item1
@@ -73945,15 +74482,15 @@ class Mission
 										position[]={82,5.0014391,27.049999};
 									};
 									side="Independent";
-									flags=5;
+									flags=4;
 									class Attributes
 									{
-										name="AAF_ENG_ENG2";
-										description="Engineer (Explosives)@AAF ENG";
+										name="IND_LOGI_LOGI2";
+										description="Engineer@INDFOR LOGI";
 										isPlayable=1;
 									};
-									id=1273;
-									type="I_Soldier_exp_F";
+									id=1617;
+									type="I_engineer_F";
 									class CustomAttributes
 									{
 										class Attribute0
@@ -73990,7 +74527,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -74104,7 +74641,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""eng"",""ind_f"",true]";
+													value="[""logi"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -74123,7 +74660,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="eng";
+													value="logi";
 												};
 											};
 										};
@@ -74138,15 +74675,15 @@ class Mission
 										position[]={84,5.0014391,27.049999};
 									};
 									side="Independent";
-									flags=5;
+									flags=4;
 									class Attributes
 									{
-										name="AAF_ENG_ENGM1";
-										description="Engineer (Mines)@AAF ENG";
+										name="IND_LOGI_LOGIM1";
+										description="Engineer@INDFOR LOGI";
 										isPlayable=1;
 									};
-									id=1274;
-									type="I_soldier_mine_F";
+									id=1618;
+									type="I_engineer_F";
 									class CustomAttributes
 									{
 										class Attribute0
@@ -74183,7 +74720,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -74278,7 +74815,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""engm"",""ind_f"",true]";
+													value="[""logi"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -74297,7 +74834,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="engm";
+													value="logi";
 												};
 											};
 										};
@@ -74312,15 +74849,15 @@ class Mission
 										position[]={85,5.0014391,26.049999};
 									};
 									side="Independent";
-									flags=5;
+									flags=4;
 									class Attributes
 									{
-										name="AAF_ENG_ENGM2";
-										description="Engineer (Mines)@AAF ENG";
+										name="IND_LOGI_LOGIM2";
+										description="Engineer@INDFOR LOGI";
 										isPlayable=1;
 									};
-									id=1275;
-									type="I_soldier_mine_F";
+									id=1619;
+									type="I_engineer_F";
 									class CustomAttributes
 									{
 										class Attribute0
@@ -74357,7 +74894,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -74471,7 +75008,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""engm"",""ind_f"",true]";
+													value="[""logi"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -74490,7 +75027,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="engm";
+													value="logi";
 												};
 											};
 										};
@@ -74500,7 +75037,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="AAF_ENG_GRP";
+								name="IND_LOGI_GRP";
 							};
 							id=1271;
 							class CustomAttributes
@@ -74520,7 +75057,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -74539,14 +75076,14 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[""x\tmf\addons\orbat\textures\gray_engineer.paa"",""ENG"",""x\tmf\addons\orbat\textures\modif_o.paa"",14]";
+											value="[""x\tmf\addons\orbat\textures\gray_engineer.paa"",""ENG"",""x\tmf\addons\orbat\textures\modif_o.paa"",8]";
 										};
 									};
 								};
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -74558,7 +75095,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="AAF ENG";
+											value="INDFOR LOGI";
 										};
 									};
 								};
@@ -74622,8 +75159,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="AAF_M1_VC";
-										description="Commander@AAF Mike 1";
+										name="IND_M1_VC";
+										description="Commander@INDFOR Mike 1";
 										isPlayable=1;
 									};
 									id=1356;
@@ -74664,7 +75201,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -74759,7 +75296,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""vc"",""ind_f"",true]";
+													value="[""vc"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -74796,8 +75333,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_M1_VG";
-										description="Gunner@AAF Mike 1";
+										name="IND_M1_VG";
+										description="Gunner@INDFOR Mike 1";
 										isPlayable=1;
 									};
 									id=1357;
@@ -74819,7 +75356,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""vg"",""ind_f"",true]";
+													value="[""vg"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -74914,7 +75451,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -74932,8 +75469,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_M1_VD";
-										description="Driver@AAF Mike 1";
+										name="IND_M1_VD";
+										description="Driver@INDFOR Mike 1";
 										isPlayable=1;
 									};
 									id=1358;
@@ -74974,7 +75511,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -75000,7 +75537,7 @@ class Mission
 										class Attribute3
 										{
 											property="ace_isEngineer";
-											expression="if !(_value == ([0,1] select (_this getUnitTrait 'engineer'))|| {_value == -1}) then {_this setVariable ['ace_isEngineer', _value, true]}";
+											expression="if !(_value == ([0, 1] select (_this getUnitTrait 'engineer')) || {_value == -1}) then {_this setVariable ['ace_isEngineer', _value, true]}";
 											class Value
 											{
 												class data
@@ -75050,7 +75587,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""vd"",""ind_f"",true]";
+													value="[""vd"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -75079,7 +75616,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="AAF_M1_GRP";
+								name="IND_M1_GRP";
 							};
 							id=1355;
 							class CustomAttributes
@@ -75099,7 +75636,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -75125,7 +75662,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -75137,7 +75674,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="AAF M1";
+											value="INDFOR M1";
 										};
 									};
 								};
@@ -75201,8 +75738,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="AAF_M2_VC";
-										description="Commander@AAF Mike 2";
+										name="IND_M2_VC";
+										description="Commander@INDFOR Mike 2";
 										isPlayable=1;
 									};
 									id=1360;
@@ -75243,7 +75780,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -75338,7 +75875,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""vc"",""ind_f"",true]";
+													value="[""vc"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -75375,8 +75912,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_M2_VG";
-										description="Gunner@AAF Mike 2";
+										name="IND_M2_VG";
+										description="Gunner@INDFOR Mike 2";
 										isPlayable=1;
 									};
 									id=1361;
@@ -75398,7 +75935,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""vg"",""ind_f"",true]";
+													value="[""vg"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -75493,7 +76030,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -75511,8 +76048,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_M2_VD";
-										description="Driver@AAF Mike 2";
+										name="IND_M2_VD";
+										description="Driver@INDFOR Mike 2";
 										isPlayable=1;
 									};
 									id=1362;
@@ -75553,7 +76090,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -75579,7 +76116,7 @@ class Mission
 										class Attribute3
 										{
 											property="ace_isEngineer";
-											expression="if !(_value == ([0,1] select (_this getUnitTrait 'engineer'))|| {_value == -1}) then {_this setVariable ['ace_isEngineer', _value, true]}";
+											expression="if !(_value == ([0, 1] select (_this getUnitTrait 'engineer')) || {_value == -1}) then {_this setVariable ['ace_isEngineer', _value, true]}";
 											class Value
 											{
 												class data
@@ -75629,7 +76166,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""vd"",""ind_f"",true]";
+													value="[""vd"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -75658,7 +76195,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="AAF_M2_GRP";
+								name="IND_M2_GRP";
 							};
 							id=1359;
 							class CustomAttributes
@@ -75678,7 +76215,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -75704,7 +76241,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -75716,7 +76253,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="AAF M2";
+											value="INDFOR M2";
 										};
 									};
 								};
@@ -75780,8 +76317,8 @@ class Mission
 									class Attributes
 									{
 										rank="SERGEANT";
-										name="AAF_G1_VC";
-										description="Commander@AAF Gambler 1";
+										name="IND_G1_VC";
+										description="Commander@INDFOR Gambler 1";
 										isPlayable=1;
 									};
 									id=1372;
@@ -75822,7 +76359,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -75917,7 +76454,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""vc"",""ind_f"",true]";
+													value="[""vc"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -75955,8 +76492,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="AAF_G1_VG";
-										description="Gunner@AAF Gambler 1";
+										name="IND_G1_VG";
+										description="Gunner@INDFOR Gambler 1";
 										isPlayable=1;
 									};
 									id=1373;
@@ -75978,7 +76515,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""vg"",""ind_f"",true]";
+													value="[""vg"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -76073,7 +76610,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -76091,8 +76628,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_G1_VD";
-										description="Driver@AAF Gambler 1";
+										name="IND_G1_VD";
+										description="Driver@INDFOR Gambler 1";
 										isPlayable=1;
 									};
 									id=1374;
@@ -76133,7 +76670,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -76159,7 +76696,7 @@ class Mission
 										class Attribute3
 										{
 											property="ace_isEngineer";
-											expression="if !(_value == ([0,1] select (_this getUnitTrait 'engineer'))|| {_value == -1}) then {_this setVariable ['ace_isEngineer', _value, true]}";
+											expression="if !(_value == ([0, 1] select (_this getUnitTrait 'engineer')) || {_value == -1}) then {_this setVariable ['ace_isEngineer', _value, true]}";
 											class Value
 											{
 												class data
@@ -76209,7 +76746,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""vd"",""ind_f"",true]";
+													value="[""vd"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -76238,7 +76775,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="AAF_G1_GRP";
+								name="IND_G1_GRP";
 							};
 							id=1371;
 							class CustomAttributes
@@ -76258,7 +76795,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -76284,7 +76821,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -76296,7 +76833,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="AAF G1";
+											value="INDFOR G1";
 										};
 									};
 								};
@@ -76360,8 +76897,8 @@ class Mission
 									class Attributes
 									{
 										rank="SERGEANT";
-										name="AAF_G2_VC";
-										description="Commander@AAF Gambler 2";
+										name="IND_G2_VC";
+										description="Commander@INDFOR Gambler 2";
 										isPlayable=1;
 									};
 									id=1376;
@@ -76402,7 +76939,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -76497,7 +77034,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""vc"",""ind_f"",true]";
+													value="[""vc"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -76535,8 +77072,8 @@ class Mission
 									class Attributes
 									{
 										rank="CORPORAL";
-										name="AAF_G2_VG";
-										description="Gunner@AAF Gambler 2";
+										name="IND_G2_VG";
+										description="Gunner@INDFOR Gambler 2";
 										isPlayable=1;
 									};
 									id=1377;
@@ -76558,7 +77095,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""vg"",""ind_f"",true]";
+													value="[""vg"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -76653,7 +77190,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -76671,8 +77208,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_G2_VD";
-										description="Driver@AAF Gambler 2";
+										name="IND_G2_VD";
+										description="Driver@INDFOR Gambler 2";
 										isPlayable=1;
 									};
 									id=1378;
@@ -76713,7 +77250,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -76739,7 +77276,7 @@ class Mission
 										class Attribute3
 										{
 											property="ace_isEngineer";
-											expression="if !(_value == ([0,1] select (_this getUnitTrait 'engineer'))|| {_value == -1}) then {_this setVariable ['ace_isEngineer', _value, true]}";
+											expression="if !(_value == ([0, 1] select (_this getUnitTrait 'engineer')) || {_value == -1}) then {_this setVariable ['ace_isEngineer', _value, true]}";
 											class Value
 											{
 												class data
@@ -76789,7 +77326,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""vd"",""ind_f"",true]";
+													value="[""vd"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -76818,7 +77355,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="AAF_G2_GRP";
+								name="IND_G2_GRP";
 							};
 							id=1375;
 							class CustomAttributes
@@ -76838,7 +77375,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[6]";
+											value="[]";
 										};
 									};
 								};
@@ -76864,7 +77401,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -76876,7 +77413,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="AAF G2";
+											value="INDFOR G2";
 										};
 									};
 								};
@@ -76940,8 +77477,8 @@ class Mission
 									class Attributes
 									{
 										rank="LIEUTENANT";
-										name="AAF_PHT1_HP";
-										description="Pilot@AAF Phantom 1";
+										name="IND_PHT1_HP";
+										description="Pilot@INDFOR Phantom 1";
 										isPlayable=1;
 									};
 									id=1388;
@@ -76982,7 +77519,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -77077,7 +77614,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hp"",""ind_f"",true]";
+													value="[""hp"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -77115,8 +77652,8 @@ class Mission
 									class Attributes
 									{
 										rank="SERGEANT";
-										name="AAF_PHT1_HCC";
-										description="Copilot@AAF Phantom 1";
+										name="IND_PHT1_HCC";
+										description="Copilot@INDFOR Phantom 1";
 										isPlayable=1;
 									};
 									id=1389;
@@ -77157,7 +77694,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -77252,7 +77789,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hcc"",""ind_f"",true]";
+													value="[""hcc"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -77289,8 +77826,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_PHT1_HC1";
-										description="Door Gunner@AAF Phantom 1";
+										name="IND_PHT1_HC1";
+										description="Door Gunner@INDFOR Phantom 1";
 										isPlayable=1;
 									};
 									id=1390;
@@ -77331,7 +77868,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -77426,7 +77963,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hc"",""ind_f"",true]";
+													value="[""hc"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -77463,8 +78000,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_PHT1_HC2";
-										description="Door Gunner@AAF Phantom 1";
+										name="IND_PHT1_HC2";
+										description="Door Gunner@INDFOR Phantom 1";
 										isPlayable=1;
 									};
 									id=1391;
@@ -77505,7 +78042,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -77600,7 +78137,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hc"",""ind_f"",true]";
+													value="[""hc"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -77629,7 +78166,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="AAF_PHT1_GRP";
+								name="IND_PHT1_GRP";
 							};
 							id=1387;
 							class CustomAttributes
@@ -77675,7 +78212,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -77687,7 +78224,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="AAF PHT1";
+											value="INDFOR PHT1";
 										};
 									};
 								};
@@ -77751,8 +78288,8 @@ class Mission
 									class Attributes
 									{
 										rank="LIEUTENANT";
-										name="AAF_PHT2_HP";
-										description="Pilot@AAF Phantom 2";
+										name="IND_PHT2_HP";
+										description="Pilot@INDFOR Phantom 2";
 										isPlayable=1;
 									};
 									id=1393;
@@ -77793,7 +78330,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -77888,7 +78425,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hp"",""ind_f"",true]";
+													value="[""hp"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -77926,8 +78463,8 @@ class Mission
 									class Attributes
 									{
 										rank="SERGEANT";
-										name="AAF_PHT2_HCC";
-										description="Copilot@AAF Phantom 2";
+										name="IND_PHT2_HCC";
+										description="Copilot@INDFOR Phantom 2";
 										isPlayable=1;
 									};
 									id=1394;
@@ -77968,7 +78505,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -78063,7 +78600,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hcc"",""ind_f"",true]";
+													value="[""hcc"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -78100,8 +78637,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_PHT2_HC1";
-										description="Door Gunner@AAF Phantom 2";
+										name="IND_PHT2_HC1";
+										description="Door Gunner@INDFOR Phantom 2";
 										isPlayable=1;
 									};
 									id=1395;
@@ -78142,7 +78679,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -78237,7 +78774,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hc"",""ind_f"",true]";
+													value="[""hc"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -78274,8 +78811,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_PHT2_HC2";
-										description="Door Gunner@AAF Phantom 2";
+										name="IND_PHT2_HC2";
+										description="Door Gunner@INDFOR Phantom 2";
 										isPlayable=1;
 									};
 									id=1396;
@@ -78316,7 +78853,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -78411,7 +78948,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hc"",""ind_f"",true]";
+													value="[""hc"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -78440,7 +78977,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="AAF_PHT2_GRP";
+								name="IND_PHT2_GRP";
 							};
 							id=1392;
 							class CustomAttributes
@@ -78486,7 +79023,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -78498,7 +79035,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="AAF PHT2";
+											value="INDFOR PHT2";
 										};
 									};
 								};
@@ -78562,8 +79099,8 @@ class Mission
 									class Attributes
 									{
 										rank="LIEUTENANT";
-										name="AAF_RVN1_HP";
-										description="Pilot@AAF Raven 1";
+										name="IND_RVN1_HP";
+										description="Pilot@INDFOR Raven 1";
 										isPlayable=1;
 									};
 									id=1408;
@@ -78604,7 +79141,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -78699,7 +79236,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hp"",""ind_f"",true]";
+													value="[""hp"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -78737,8 +79274,8 @@ class Mission
 									class Attributes
 									{
 										rank="SERGEANT";
-										name="AAF_RVN1_HCC";
-										description="Copilot@AAF Raven 1";
+										name="IND_RVN1_HCC";
+										description="Copilot@INDFOR Raven 1";
 										isPlayable=1;
 									};
 									id=1409;
@@ -78779,7 +79316,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -78874,7 +79411,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hcc"",""ind_f"",true]";
+													value="[""hcc"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -78903,7 +79440,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="AAF_RVN1_GRP";
+								name="IND_RVN1_GRP";
 							};
 							id=1407;
 							class CustomAttributes
@@ -78949,7 +79486,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -78961,7 +79498,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="AAF RVN1";
+											value="INDFOR RVN1";
 										};
 									};
 								};
@@ -79025,8 +79562,8 @@ class Mission
 									class Attributes
 									{
 										rank="LIEUTENANT";
-										name="AAF_RVN2_HP";
-										description="Pilot@AAF Raven 2";
+										name="IND_RVN2_HP";
+										description="Pilot@INDFOR Raven 2";
 										isPlayable=1;
 									};
 									id=1411;
@@ -79067,7 +79604,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -79181,7 +79718,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hp"",""ind_f"",true]";
+													value="[""hp"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -79219,8 +79756,8 @@ class Mission
 									class Attributes
 									{
 										rank="SERGEANT";
-										name="AAF_RVN2_HCC";
-										description="Copilot@AAF Raven 2";
+										name="IND_RVN2_HCC";
+										description="Copilot@INDFOR Raven 2";
 										isPlayable=1;
 									};
 									id=1412;
@@ -79261,7 +79798,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -79375,7 +79912,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""hcc"",""ind_f"",true]";
+													value="[""hcc"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -79404,7 +79941,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="AAF_RVN2_GRP";
+								name="IND_RVN2_GRP";
 							};
 							id=1410;
 							class CustomAttributes
@@ -79450,7 +79987,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -79462,7 +79999,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="AAF RVN2";
+											value="INDFOR RVN2";
 										};
 									};
 								};
@@ -79525,8 +80062,8 @@ class Mission
 									flags=7;
 									class Attributes
 									{
-										name="AAF_FLC_JP1";
-										description="Pilot@AAF Falcon";
+										name="IND_TLN_JP1";
+										description="Pilot@INDFOR Talon";
 										isPlayable=1;
 									};
 									id=1535;
@@ -79567,7 +80104,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -79681,7 +80218,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""jp"",""ind_f"",true]";
+													value="[""jp"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -79718,8 +80255,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_FLC_JP2";
-										description="Pilot@AAF Falcon";
+										name="IND_TLN_JP2";
+										description="Pilot@INDFOR Talon";
 										isPlayable=1;
 									};
 									id=1536;
@@ -79760,7 +80297,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -79855,7 +80392,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""jp"",""ind_f"",true]";
+													value="[""jp"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -79884,7 +80421,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="AAF_FLC_GRP";
+								name="IND_FLC_GRP";
 							};
 							id=1534;
 							class CustomAttributes
@@ -79923,14 +80460,14 @@ class Mission
 													"STRING"
 												};
 											};
-											value="[""x\tmf\addons\orbat\textures\purple_fixedwing.paa"",""FLC"","""",7]";
+											value="[""x\tmf\addons\orbat\textures\purple_fixedwing.paa"",""TLN"","""",7]";
 										};
 									};
 								};
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -79942,7 +80479,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="AAF FLC";
+											value="INDFOR TLN";
 										};
 									};
 								};
@@ -80005,8 +80542,8 @@ class Mission
 									flags=7;
 									class Attributes
 									{
-										name="AAF_JIP_R1";
-										description="Spare Rifleman@AAF JIP";
+										name="IND_JIP_R1";
+										description="Spare Rifleman@INDFOR JIP";
 										isPlayable=1;
 									};
 									id=1553;
@@ -80047,7 +80584,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -80142,7 +80679,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""ind_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -80160,8 +80697,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_JIP_R2";
-										description="Spare Rifleman@AAF JIP";
+										name="IND_JIP_R2";
+										description="Spare Rifleman@INDFOR JIP";
 										isPlayable=1;
 									};
 									id=1554;
@@ -80202,7 +80739,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -80297,7 +80834,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""ind_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -80315,8 +80852,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_JIP_R3";
-										description="Spare Rifleman@AAF JIP";
+										name="IND_JIP_R3";
+										description="Spare Rifleman@INDFOR JIP";
 										isPlayable=1;
 									};
 									id=1555;
@@ -80357,7 +80894,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -80452,7 +80989,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""ind_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -80470,8 +81007,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_JIP_R4";
-										description="Spare Rifleman@AAF JIP";
+										name="IND_JIP_R4";
+										description="Spare Rifleman@INDFOR JIP";
 										isPlayable=1;
 									};
 									id=1556;
@@ -80512,7 +81049,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -80607,7 +81144,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""ind_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -80625,8 +81162,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_JIP_R5";
-										description="Spare Rifleman@AAF JIP";
+										name="IND_JIP_R5";
+										description="Spare Rifleman@INDFOR JIP";
 										isPlayable=1;
 									};
 									id=1557;
@@ -80667,7 +81204,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -80762,7 +81299,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""ind_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -80780,8 +81317,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_JIP_R6";
-										description="Spare Rifleman@AAF JIP";
+										name="IND_JIP_R6";
+										description="Spare Rifleman@INDFOR JIP";
 										isPlayable=1;
 									};
 									id=1558;
@@ -80822,7 +81359,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -80917,7 +81454,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""ind_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -80935,8 +81472,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_JIP_R7";
-										description="Spare Rifleman@AAF JIP";
+										name="IND_JIP_R7";
+										description="Spare Rifleman@INDFOR JIP";
 										isPlayable=1;
 									};
 									id=1559;
@@ -80977,7 +81514,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -81072,7 +81609,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""ind_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -81090,8 +81627,8 @@ class Mission
 									flags=5;
 									class Attributes
 									{
-										name="AAF_JIP_R8";
-										description="Spare Rifleman@AAF JIP";
+										name="IND_JIP_R8";
+										description="Spare Rifleman@INDFOR JIP";
 										isPlayable=1;
 									};
 									id=1560;
@@ -81132,7 +81669,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="ind_f";
+													value="example_loadout";
 												};
 											};
 										};
@@ -81227,7 +81764,7 @@ class Mission
 															"STRING"
 														};
 													};
-													value="[""r"",""ind_f"",true]";
+													value="[""r"",""example_loadout"",true]";
 												};
 											};
 										};
@@ -81237,7 +81774,7 @@ class Mission
 							};
 							class Attributes
 							{
-								name="AAF_JIP_GRP";
+								name="IND_JIP_GRP";
 							};
 							id=1552;
 							class CustomAttributes
@@ -81283,7 +81820,7 @@ class Mission
 								class Attribute2
 								{
 									property="groupID";
-									expression="[_this, _value] call CBA_fnc_setCallsign";
+									expression="                            if (isNil 'CBA_fnc_setCallsign') then {                                _this setGroupID [_value];                            } else {                                [_this, _value] call CBA_fnc_setCallsign;                            };                        ";
 									class Value
 									{
 										class data
@@ -81295,7 +81832,7 @@ class Mission
 													"STRING"
 												};
 											};
-											value="AAF JIP";
+											value="INDFOR JIP";
 										};
 									};
 								};

--- a/ARCMT.vr/mission.sqm
+++ b/ARCMT.vr/mission.sqm
@@ -31,26 +31,8 @@ addons[]=
 	"A3_Weapons_F_Rifles_MX",
 	"A3_Sounds_F",
 	"A3_Sounds_F_Enoch",
-	"ace_realisticnames",
-	"ace_scopes",
-	"ace_ai",
-	"ace_ballistics",
 	"A3_Weapons_F_Acc",
-	"ace_laserpointer",
 	"A3_Weapons_F",
-	"ace_smallarms",
-	"ace_csw",
-	"ace_vector",
-	"acre_main",
-	"ace_medical_treatment",
-	"ace_trenches",
-	"ace_mk6mortar",
-	"ace_maptools",
-	"ace_hearing",
-	"ace_explosives",
-	"ace_nouniformrestrictions",
-	"ace_gforces",
-	"ace_parachute",
 	"A3_Modules_F_Curator_Curator",
 	"TMF_safestart",
 	"tmf_spectator",
@@ -60,7 +42,7 @@ class AddonsMetaData
 {
 	class List
 	{
-		items=25;
+		items=9;
 		class Item0
 		{
 			className="A3_Characters_F";
@@ -98,138 +80,26 @@ class AddonsMetaData
 		};
 		class Item5
 		{
-			className="ace_scopes";
-			name="ACE3 - Scopes";
-			author="ACE-Team";
-			url="http://ace3mod.com/";
-		};
-		class Item6
-		{
-			className="ace_ai";
-			name="ACE3 - AI";
-			author="ACE-Team";
-			url="http://ace3mod.com/";
-		};
-		class Item7
-		{
-			className="ace_ballistics";
-			name="ACE3 - Ballistics";
-			author="ACE-Team";
-			url="http://ace3mod.com/";
-		};
-		class Item8
-		{
-			className="ace_laserpointer";
-			name="ACE3 - Laser Pointer";
-			author="ACE-Team";
-			url="http://ace3mod.com/";
-		};
-		class Item9
-		{
-			className="ace_smallarms";
-			name="ACE3 - Small Arms";
-			author="ACE-Team";
-			url="http://ace3mod.com/";
-		};
-		class Item10
-		{
-			className="ace_csw";
-			name="ACE3 - Crew-Served Weapons";
-			author="ACE-Team";
-			url="http://ace3mod.com/";
-		};
-		class Item11
-		{
-			className="ace_vector";
-			name="ACE3 - Vector";
-			author="ACE-Team";
-			url="http://ace3mod.com/";
-		};
-		class Item12
-		{
-			className="acre_main";
-			name="ACRE2 - Main";
-			author="ACRE2Team";
-			url="https://github.com/IDI-Systems/acre2";
-		};
-		class Item13
-		{
-			className="ace_medical_treatment";
-			name="ACE3 - Medical Treatment";
-			author="ACE-Team";
-			url="http://ace3mod.com/";
-		};
-		class Item14
-		{
-			className="ace_trenches";
-			name="ACE3 - Trenches";
-			author="ACE-Team";
-			url="http://ace3mod.com/";
-		};
-		class Item15
-		{
-			className="ace_mk6mortar";
-			name="ACE3 - Mk6 Mortar";
-			author="ACE-Team";
-			url="http://ace3mod.com/";
-		};
-		class Item16
-		{
-			className="ace_maptools";
-			name="ACE3 - Map Tools";
-			author="ACE-Team";
-			url="http://ace3mod.com/";
-		};
-		class Item17
-		{
-			className="ace_hearing";
-			name="ACE3 - Hearing";
-			author="ACE-Team";
-			url="http://ace3mod.com/";
-		};
-		class Item18
-		{
-			className="ace_explosives";
-			name="ACE3 - Explosives";
-			author="ACE-Team";
-			url="http://ace3mod.com/";
-		};
-		class Item19
-		{
-			className="ace_nouniformrestrictions";
-			name="ACE3 - No Uniform Restrictions";
-			author="ACE-Team";
-			url="http://ace3mod.com/";
-		};
-		class Item20
-		{
-			className="ace_parachute";
-			name="ACE3 - Parachute";
-			author="ACE-Team";
-			url="http://ace3mod.com/";
-		};
-		class Item21
-		{
 			className="A3_Modules_F_Curator";
 			name="Arma 3 Zeus Update - Scripted Modules";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item22
+		class Item6
 		{
 			className="TMF_safestart";
 			name="TMF: Safestart";
 			author="Head";
 			url="http://www.teamonetactical.com";
 		};
-		class Item23
+		class Item7
 		{
 			className="TMF_spectator";
 			name="TMF: Spectator";
 			author="Head";
 			url="http://www.teamonetactical.com";
 		};
-		class Item24
+		class Item8
 		{
 			className="A3_Data_F_Curator";
 			name="Arma 3 Zeus Update - Main Configuration";
@@ -245,10 +115,6 @@ class DynamicSimulation
 		Vehicle=1000;
 		Group=1000;
 	};
-};
-dlcs[]=
-{
-	"Mark"
 };
 randomSeed=652147;
 class ScenarioData


### PR DESCRIPTION
> [15:44] Saquesh: @Admin Please greenlight the following changes to the framework:
> Changes:
> - Only Command are on Command Short Range
> - Medics given binos
> - Fireteam members given Entrenchment Tools, but removed from SMG
> - Logi role added, inherits from CAR. Has engineer trait and a large backpack with toolkit
> - Engi roles merged into 1 Engi role, inherits from Logi. Has explosive specialist trait added. No explosives given but has clacker. Mission Makers to adjust to fit purpose
> - Falcon renamed to Talon
> - NATO/CSAT/AAF all changed to BLUFOR/OPFOR/INDFOR
> - Engi team made to be Logi team. Role descriptions updated with leader being called "Team Leader" as arma doesn't like it when all roles in a group have same starting word (it removes that word so you end up with "(Mines)@Engi" which is dumb)
> - Made framework units use example_loadout instead of the built in 2035 ones. If we change the framework again to add new roles then it makes sense

> [22:23] Saquesh: @Admin please sign off again on framework changes:
> 
> - Added 3 cableties to baseman of example loadout
> 
> Also for clarity, last change added a Logi team and made Eng inherit from it. We removed EngM which will throw errors for people when updating their mission. This is by design to force them to adjust the loadout file
> 
> Expectation is on MMs to make engineer loadout fit for purpose instead of generic. Generic engineer loadouts are less than useless and already part of testing under mission design - Could be that mission testing checklist requires an update to reflect this

From me: Also added example usage of `import` to modify a role in the repo, without downloading and modifying the loadout file itself.